### PR TITLE
00systemd: add missing cryptsetup-related targets

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -52,6 +52,8 @@ install() {
         $systemdutildir/system-generators/systemd-gpt-auto-generator \
         \
         $systemdsystemunitdir/cryptsetup.target \
+        $systemdsystemunitdir/cryptsetup-pre.target \
+        $systemdsystemunitdir/remote-cryptsetup.target \
         $systemdsystemunitdir/emergency.target \
         $systemdsystemunitdir/sysinit.target \
         $systemdsystemunitdir/basic.target \


### PR DESCRIPTION
We want these in the initramfs. Things related to clevis and systemd's
`cryptsetup-generator` reference these targets.

(cherry picked from commit 7c923f1de89f80b511338f9b434acfdf2547dbac)