### PR TITLE
make collect optional

### DIFF
--- a/modules.d/95dasd_rules/module-setup.sh
+++ b/modules.d/95dasd_rules/module-setup.sh
@@ -22,7 +22,6 @@ check() {
     local found=0
     local bdev
     [ "$_arch" = "s390" -o "$_arch" = "s390x" ] || return 1
-    require_binaries /usr/lib/udev/collect || return 1
 
     [[ $hostonly ]] || [[ $mount_needs ]] && {
         for bdev in /sys/block/* ; do
@@ -45,7 +44,7 @@ depends() {
 
 # called by dracut
 install() {
-    inst_multiple /usr/lib/udev/collect
+    [[ -f /usr/lib/udev/collect ]] && inst_multiple /usr/lib/udev/collect
     inst_hook cmdline 30 "$moddir/parse-dasd.sh"
     if [[ $hostonly_cmdline == "yes" ]] ; then
         local _dasd=$(cmdline)

--- a/modules.d/95qeth_rules/module-setup.sh
+++ b/modules.d/95qeth_rules/module-setup.sh
@@ -5,7 +5,6 @@ check() {
     local _arch=$(uname -m)
     local _online=0
     [ "$_arch" = "s390" -o "$_arch" = "s390x" ] || return 1
-    require_binaries /usr/lib/udev/collect || return 1
     dracut_module_included network || return 1
 
     [[ $hostonly ]] && {
@@ -55,5 +54,5 @@ install() {
         [ -n "$id" ] && inst_rules_qeth $id
     done
 
-    inst_simple /usr/lib/udev/collect
+    [[ -f /usr/lib/udev/collect ]] && inst_simple /usr/lib/udev/collect
 }

--- a/modules.d/95zfcp_rules/module-setup.sh
+++ b/modules.d/95zfcp_rules/module-setup.sh
@@ -41,7 +41,6 @@ check() {
     local _arch=$(uname -m)
     local _ccw
     [ "$_arch" = "s390" -o "$_arch" = "s390x" ] || return 1
-    require_binaries /usr/lib/udev/collect || return 1
 
     [[ $hostonly ]] || [[ $mount_needs ]] && {
         found=0
@@ -61,7 +60,7 @@ depends() {
 
 # called by dracut
 install() {
-    inst_multiple /usr/lib/udev/collect
+    [[ -f /usr/lib/udev/collect ]] && inst_multiple /usr/lib/udev/collect
     inst_hook cmdline 30 "$moddir/parse-zfcp.sh"
     if [[ $hostonly_cmdline == "yes" ]] ; then
         local _zfcp


### PR DESCRIPTION
/usr/lib/udev/collect has been removed from udev-v246, so make it optional

this is a temporary workaround for bug#1177870

A more throughout solution will follow later.