### PR TITLE
90kernel-modules: arm/arm64: Add reset controllers

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -84,6 +84,7 @@ installkernel() {
                 "=drivers/phy" \
                 "=drivers/power" \
                 "=drivers/regulator" \
+                "=drivers/reset" \
                 "=drivers/rpmsg" \
                 "=drivers/rtc" \
                 "=drivers/soc" \


### PR DESCRIPTION
Reset controllers might be needed by some of the devices used in the
initrd. Particularly on the Raspberry Pi 4, 'xhci-pci' depends on a
platform specific reset controller.

Signed-off-by: Nicolas Saenz Julienne <nsaenzjulienne@suse.de>
Reference: bsc#1180336

Note: This was also sent upstream, but I'm trying to get it down to release 49.1 so as to get the fix in leap 15.3.