### PR TITLE
90kernel-modules-extra: don't resolve symlinks before instmod (bsc#1185277)

### DIFF
--- a/modules.d/90kernel-modules-extra/module-setup.sh
+++ b/modules.d/90kernel-modules-extra/module-setup.sh
@@ -187,7 +187,7 @@ installkernel()
 	printf "^%s\.ko(\.gz|\.bz2|\.xz)?:\n" "${pathlist[@]}" \
 		| (LANG=C grep -E -o -f - -- "$depmod_modules_dep" || exit 0) \
 		| tr -d ':' \
-		| (cd "$depmod_module_dir" || exit; xargs -r realpath -e --) \
+		| (cd "$depmod_module_dir" || exit; xargs -r realpath -se --) \
 		| instmods || return 1
 
 	return 0


### PR DESCRIPTION
When you install a third-party driver, you will probably end in a
situation, where the module will be in a different directory and
in $depmod_module_dir you will only have symlink. If we resolve the
symlink before we pass the module path to instmod, the dracut-install
will only include the module with its original path, but not the
symlink. Hence the module can't be automatically loaded.

Dracut-install is clever enough to handle symlinks and will include both
the symlink and the module to the initrd.

(cherry picked from commit d1afff43aea01c8d43817adf3ac4041dd4b9f022)