### PR TITLE
FIx 99suse-initrd

### DIFF
--- a/modules.d/99suse-initrd/module-setup.sh
+++ b/modules.d/99suse-initrd/module-setup.sh
@@ -14,7 +14,8 @@ check() {
 }
 
 get_modprobe_conf_files() {
-    ls /etc/modprobe.d/*.conf /run/modules.d/*.conf /lib/modules.d/*.conf \
+    ls /etc/modprobe.d/*.conf /run/modprobe.d/*.conf \
+       /lib/modprobe.d/*.conf /usr/lib/modprobe.d/*.conf \
        2>/dev/null
     return 0
 }


### PR DESCRIPTION
This pull request changes 99suse-initrd module
This PR must also be applied to all follow-up SUSE branches.

## Changes
- fix list of `modprobe.d` directories

## Checklist
- [ x] I have tested it locally

Fixes bsc#1186560
