### PR TITLE
chore(suse): fix specfile for usrmerge

### DIFF
--- a/suse/dracut.spec
+++ b/suse/dracut.spec
@@ -263,7 +263,6 @@ fi
 %files mkinitrd-deprecated
 %defattr(-,root,root,0755)
 %{_sbindir}/mkinitrd
-/sbin/mkinitrd
 %{_mandir}/man8/mkinitrd.8*
 
 %files


### PR DESCRIPTION
This pull request fixes the suse specfile for usrmerge

## Changes
remove references to /sbin since binaries are now in /usr/sbin

Fixes #
build error in tumbleweed