### PR TITLE
chore(suse): erase conditional for usrmerge from specfile

### DIFF
--- a/suse/dracut.spec
+++ b/suse/dracut.spec
@@ -274,9 +274,6 @@ fi
 %{_bindir}/dracut
 %{_bindir}/lsinitrd
 %{_sbindir}/installkernel
-%if !0%{?usrmerged}
-/sbin/installkernel
-%endif
 %{_datarootdir}/bash-completion/completions/lsinitrd
 %{_datadir}/pkgconfig/dracut.pc
 


### PR DESCRIPTION
versions >053 are only in tumbleweed where usrmerge is in place
no need to have a conditional

This pull request changes...

## Changes

dracut.spec for SUSE

## Checklist
- [ x ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
