### PR TITLE
Fix usrmerge in specfile

### DIFF
--- a/suse/dracut.spec
+++ b/suse/dracut.spec
@@ -263,7 +263,6 @@ fi
 %files mkinitrd-deprecated
 %defattr(-,root,root,0755)
 %{_sbindir}/mkinitrd
-/sbin/mkinitrd
 %{_mandir}/man8/mkinitrd.8*
 
 %files

--- a/suse/dracut.spec
+++ b/suse/dracut.spec
@@ -156,13 +156,6 @@ install -m 0644 suse/s390x_persistent_device.conf %{buildroot}%{_sysconfdir}/dra
 install -D -m 0755 suse/mkinitrd-suse.sh %{buildroot}/%{_sbindir}/mkinitrd
 install -D -m 0755 suse/dracut-installkernel %{buildroot}/%{_sbindir}/installkernel
 
-%if !0%{?usrmerged}
-# moved to /usr/sbin, maintain /sbin compat symlinks
-mkdir -p %{buildroot}/sbin
-ln -s %{_sbindir}/mkinitrd %{buildroot}/sbin/mkinitrd
-ln -s %{_sbindir}/installkernel %{buildroot}/sbin/installkernel
-%endif
-
 mv %{buildroot}%{_mandir}/man8/mkinitrd-suse.8 %{buildroot}%{_mandir}/man8/mkinitrd.8
 
 %if 0%{?suse_version}
@@ -274,9 +267,6 @@ fi
 %{_bindir}/dracut
 %{_bindir}/lsinitrd
 %{_sbindir}/installkernel
-%if !0%{?usrmerged}
-/sbin/installkernel
-%endif
 %{_datarootdir}/bash-completion/completions/lsinitrd
 %{_datadir}/pkgconfig/dracut.pc
 


### PR DESCRIPTION
This pull request changes...

 versions >053 are only in tumbleweed where usrmerge is in place
 no need to have a conditional

## Changes

suse/dracut.spec

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
