### PR TITLE
fix(suse-initrd): remove references to INITRD_MODULES

### DIFF
--- a/suse/mkinitrd-suse.8.asc
+++ b/suse/mkinitrd-suse.8.asc
@@ -38,8 +38,8 @@ OPTIONS
     have to match the _kernel_list_. Defaults to _initrd_.
 
 **-m** _<module_list>_::
-    Modules to include in initrd, defaults to _INITRD_MODULES_ variable
-    in */etc/sysconfig/kernel*.
+    Modules to include in initrd, defaults to the settings in the
+    dracut kernel-modules module.
 
 **-f** _<feature_list>_::
     Features to be enabled for the initrd. In general mkinitrd

--- a/suse/mkinitrd-suse.sh
+++ b/suse/mkinitrd-suse.sh
@@ -56,10 +56,9 @@ usage () {
     $cmd "	-L			Disable logging."
     $cmd "	-h			This help screen."
     $cmd "	-m \"module list\"	Modules to include in initrd. Defaults to the"
-    $cmd "				INITRD_MODULES variable in /etc/sysconfig/kernel"
+    $cmd "				settings in the dracut kernel-modules module"
     $cmd "	-u \"DomU module list\"	Modules to include in initrd. Defaults to the"
-    $cmd "				DOMU_INITRD_MODULES variable in"
-    $cmd "				/etc/sysconfig/kernel."
+    $cmd "				settings in the dracut kernel-modules module"
     $cmd "	-d root_device		Root device. Defaults to the device from"
     $cmd "				which / is mounted. Overrides the rootdev"
     $cmd "				environment variable if set."
@@ -314,8 +313,8 @@ dracut_args="${dracut_args} --force"
 if [ -f /etc/sysconfig/kernel ] ; then
     . /etc/sysconfig/kernel
 fi
-[[ $module_list ]] || module_list="${INITRD_MODULES}"
-[[ $domu_module_list ]] || domu_module_list="${DOMU_INITRD_MODULES}"
+[[ $module_list ]] || module_list=""
+[[ $domu_module_list ]] || domu_module_list=""
 shopt -s extglob
 
 failed=""


### PR DESCRIPTION
This variable is not supported anymore in the dracut
mkinitrd wrapper.

This pull request changes...

mkinitrd documentation

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
