### PR TITLE
SUSE/055: take INITRD_MODULES into account

### DIFF
--- a/modules.d/99suse-initrd/module-setup.sh
+++ b/modules.d/99suse-initrd/module-setup.sh
@@ -23,7 +23,7 @@ get_modprobe_conf_files() {
 # called by dracut
 installkernel() {
     local line mod reqs all_mods=
-    local BUILT_IN_PATH="/lib/modules/$(uname -r)/modules.builtin"
+    local BUILT_IN_PATH="/lib/modules/$kernel/modules.builtin"
 
     while read -r line; do
         mod="${line##*SUSE INITRD: }"

--- a/modules.d/99suse-initrd/module-setup.sh
+++ b/modules.d/99suse-initrd/module-setup.sh
@@ -45,6 +45,6 @@ installkernel() {
     # strip whitespace
     all_mods="$(echo $all_mods)"
     if [[ "$all_mods" ]]; then
-        dracut_instmods $all_mods
+        hostonly= dracut_instmods $all_mods
     fi
 }


### PR DESCRIPTION
## Changes

Read list of modules to be added to the initrd (in addition to automatic/hostonly setup) from `INITRD_MODULES` in `/etc/sysconfig/kernel`. This makes up for the omission of the SUSE `mkinitrd` wrapper in SUSE/054 and later. `INITRD_MODULES` is still recommended in the current [KMP authors' manual](https://drivers.suse.com/doc/kmpm/Kmpm-code11.pdf).

## Checklist
- [ x] I have tested it locally
- [ x] I have reviewed and updated any documentation if relevant
- [ x] I am providing new code

Fixes bsc#1187115, bsc#1187093

Fixes two other bugs:  
 * d393f00 ("fix(suse-initrd): exclude modules that are built-in") might check built-in property against the wrong kernel
 * SUSE INITRD module deps might not be actually installed in hostonly mode.
