### PR TITLE
fix(suse-initrd): call dracut_instmods with hostonly=

### DIFF
--- a/modules.d/99suse-initrd/module-setup.sh
+++ b/modules.d/99suse-initrd/module-setup.sh
@@ -37,6 +37,6 @@ installkernel() {
     # strip whitespace
     all_mods="$(echo $all_mods)"
     if [[ "$all_mods" ]]; then
-        dracut_instmods $all_mods
+        hostonly= dracut_instmods $all_mods
     fi
 }


### PR DESCRIPTION
We've checked before if the modules that require others are in the hostonly
list. When calling dracut_instmods, we must unset hostonly in order to
force dracut_install to actually add these modules.

## Checklist
- [x ] I have tested it locally

Fixes: SUSE INITRD module dependencies may sometimes not be included in the initrd.
