### PR TITLE
fix(suse-initrd): restore INITRD_MODULES in mkinitrd script

### DIFF
--- a/mkinitrd-suse.sh
+++ b/mkinitrd-suse.sh
@@ -313,8 +313,8 @@ dracut_args="${dracut_args} --force"
 if [ -f /etc/sysconfig/kernel ] ; then
     . /etc/sysconfig/kernel
 fi
-[[ $module_list ]] || module_list=""
-[[ $domu_module_list ]] || domu_module_list=""
+[[ $module_list ]] || module_list="${INITRD_MODULES}"
+[[ $domu_module_list ]] || domu_module_list="${DOMU_INITRD_MODULES}"
 shopt -s extglob
 
 failed=""


### PR DESCRIPTION
it's still used to overwrite defaults in suse-module-tools

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
