### PR TITLE
chore(suse): add Conflicts for old suse-module-tools to specfile (bsc…

### DIFF
--- a/suse/dracut.spec
+++ b/suse/dracut.spec
@@ -57,6 +57,8 @@ Requires:       util-linux >= 2.21
 Requires:       xz
 # We use 'btrfs fi usage' that was not present before
 Conflicts:      btrfsprogs < 3.18
+# suse-module-tools >= 16.0.3 is prepared for the removal of mkinitrd-suse.sh
+Conflicts: suse-module-tools < 16.0.3
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 %{?systemd_requires}
 


### PR DESCRIPTION
…#1187115)

suse-module-tools >= 16.0.3 is prepared for the removal of mkinitrd-suse.sh

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
