### PR TITLE
fix(kernel-install): initrd vs initramfs 

### DIFF
--- a/install.d/50-dracut.install
+++ b/install.d/50-dracut.install
@@ -15,7 +15,7 @@ if [[ -d "$BOOT_DIR_ABS" ]]; then
     INITRD="initrd"
 else
     BOOT_DIR_ABS="/boot"
-    INITRD="initramfs-${KERNEL_VERSION}.img"
+    INITRD="initrd-${KERNEL_VERSION}"
 fi
 
 ret=0


### PR DESCRIPTION
In SUSE distributions the initrd image is actually called
initrd-$kernelversion rather than initramfs-$kernelversion.img