### PR TITLE
fix(fips-suse): fipscheck doesn't need the -c parameter (bsc#1187498)

### DIFF
--- a/modules.d/01fips/fips.sh
+++ b/modules.d/01fips/fips.sh
@@ -214,7 +214,7 @@ do_fips() {
         fi
 
         if [ -n "$(fipscheck)" ]; then
-            $(fipscheck) -c "${BOOT_IMAGE_HMAC}" "${BOOT_IMAGE_KERNEL}" || return 1
+            $(fipscheck) "${BOOT_IMAGE_KERNEL}" || return 1
         else
             warn "Could not find fipscheck to verify MACs"
             return 1


### PR DESCRIPTION
This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
