### PR TITLE
docs: fix reference to insmodpost module (bsc#1187774)

### DIFF
--- a/dracut.modules.7.asc
+++ b/dracut.modules.7.asc
@@ -145,8 +145,8 @@ FIXME
 
 == Writing a Module
 
-A simple example module is _96insmodpost_, which modprobes a kernel module after
-udev has settled and the basic device drivers have been loaded.
+A simple example module is _90kernel-modules_, which modprobes a kernel module
+after udev has settled and the basic device drivers have been loaded.
 
 All module installation information is in the file module-setup.sh.
 


### PR DESCRIPTION
The module 96insmodpost was renamed to 90kernel-modules since commit
5078c98a (move insmodpost and blacklisting to 90kernel-modules)

(cherry picked from commit 30ea52f88cddd99825b6bb9be79b738702cb1a6a)

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
