### PR TITLE
fix(suse-initrd): inform on usage of obsolete -f parameter (bsc#1187470)

### DIFF
--- a/mkinitrd-suse.sh
+++ b/mkinitrd-suse.sh
@@ -217,6 +217,8 @@ default_kernel_images() {
 while (($# > 0)); do
     case ${1%%=*} in
 	-f) read_arg feature_list "$@" || shift $?
+	    echo "Obsolete -f param, use add_dracutmodules+= variable in /etc/dracut.conf.d/"
+	    exit 1
 	    # Could be several features
 	    ;;
 	-k) # Would be nice to get a list of images here


### PR DESCRIPTION
This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
