### PR TITLE
fix(tpm2-tss): typo in depends()

### DIFF
--- a/modules.d/91tpm2-tss/module-setup.sh
+++ b/modules.d/91tpm2-tss/module-setup.sh
@@ -17,7 +17,7 @@ check() {
 depends() {
 
     # This module has external dependency on other module(s).
-    echo systemd-sysusers systemd-udev
+    echo systemd-sysusers systemd-udevd
     # Return 0 to include the dependent module(s) in the initramfs.
     return 0
 


### PR DESCRIPTION
There is no systemd-udev module, only systemd-udevd

(cherry picked from commit 8b17105bed69ed90582a13d97d95ee19e6581365)
