### PR TITLE
99suse-initrd: Exclude modules that are built-in (bsc#1185646)

### DIFF
--- a/modules.d/99suse-initrd/module-setup.sh
+++ b/modules.d/99suse-initrd/module-setup.sh
@@ -23,6 +23,7 @@ get_modprobe_conf_files() {
 # called by dracut
 installkernel() {
     local line mod reqs all_mods=
+    local BUILT_IN_PATH="/lib/modules/$(uname -r)/modules.builtin"
 
     while read -r line; do
         mod="${line##*SUSE INITRD: }"
@@ -30,7 +31,14 @@ installkernel() {
         reqs="${line##*REQUIRES }"
         if [[ ! $hostonly ]] || grep -q "^$mod\$" "$DRACUT_KERNEL_MODALIASES"
         then
-            all_mods="$all_mods $reqs"
+            for module in $reqs
+            do
+                if ! grep -q "/$module.ko" $BUILT_IN_PATH
+                then
+                    # The module is not built-in, so we can safely add it
+                    all_mods="$all_mods $module"
+                fi
+            done
         fi
     done <<< "$(grep -h "^# SUSE INITRD: " $(get_modprobe_conf_files))"
 

--- a/modules.d/99suse-initrd/module-setup.sh
+++ b/modules.d/99suse-initrd/module-setup.sh
@@ -23,7 +23,7 @@ get_modprobe_conf_files() {
 # called by dracut
 installkernel() {
     local line mod reqs all_mods=
-    local BUILT_IN_PATH="/lib/modules/$(uname -r)/modules.builtin"
+    local BUILT_IN_PATH="/lib/modules/$kernel/modules.builtin"
 
     while read -r line; do
         mod="${line##*SUSE INITRD: }"


### PR DESCRIPTION
This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
