### PR TITLE
fix(suse-initrd): find links of usrmerged kernels (boo#1184804)

### DIFF
--- a/suse/mkinitrd-suse.sh
+++ b/suse/mkinitrd-suse.sh
@@ -193,7 +193,12 @@ default_kernel_images() {
         # script is itself called from within the binary kernel
         # packages, and rpm does not allow recursive calls.
 
-        [ -L "$boot_dir/$kernel_image" ] && continue
+        if [ -L "$boot_dir/$kernel_image" ]; then
+            # check for usrmerged kernel. in That case the link point to
+            # /usr/lib/modules
+            link=$(readlink "$boot_dir/$kernel_image")
+            [ "${link#/usr/lib/modules}" = "$link" ] && continue
+        fi
         [ "${kernel_image%%.gz}" != "$kernel_image" ] && continue
 
         kernel_version=$(kernel_version_from_image \


### PR DESCRIPTION
This pull request changes...

## Changes

## Checklist
- [ x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
boo#1184804