### PR TITLE
fix(iscsi): add support for the new iscsiadm "no-wait" (-W) command

### DIFF
--- a/modules.d/95iscsi/module-setup.sh
+++ b/modules.d/95iscsi/module-setup.sh
@@ -188,6 +188,7 @@ install() {
     inst_multiple -o iscsiuio
     inst_libdir_file 'libgcc_s.so*'
     inst_multiple umount iscsi-iname iscsiadm iscsid
+    inst_binary sort
 
     inst_multiple -o \
         "$systemdsystemunitdir"/iscsid.socket \


### PR DESCRIPTION
remove connection timeout for iscsi firmware targets serving system root

(cherry picked from commit 7374943ae3d063f0142c969b132c4156030fda8b)

This pull request changes...

## Changes

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
