### PR TITLE
fix(kernel-modules): add blk_mq_alloc_disk and blk_cleanup_disk to blockfuncs (bsc#1190326)

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -16,7 +16,7 @@ installkernel() {
         done < "$srcmods/modules.dep"
         IFS=$_OLDIFS
     }
-    local _blockfuncs='ahci_platform_get_resources|ata_scsi_ioctl|scsi_add_host|blk_cleanup_queue|register_mtd_blktrans|scsi_esp_register|register_virtio_device|usb_stor_disconnect|mmc_add_host|sdhci_add_host|scsi_add_host_with_dma'
+    local _blockfuncs='ahci_platform_get_resources|ata_scsi_ioctl|scsi_add_host|blk_cleanup_queue|register_mtd_blktrans|scsi_esp_register|register_virtio_device|usb_stor_disconnect|mmc_add_host|sdhci_add_host|scsi_add_host_with_dma|blk_mq_alloc_disk|blk_cleanup_disk'
 
     if [[ -z $drivers ]]; then
         hostonly='' instmods \


### PR DESCRIPTION
Since kernel 5-14 those are used by many drivers for example:
xen-blkfront, loop, nbd, pd

Fixes bsc#1190326

(cherry picked from commit b292ce7295f18192124e64e5ec31161d09492160)

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes bsc#1190326
