### PR TITLE
ci(suse): set zstd as default compression

### DIFF
--- a/dracut.conf.d/suse.conf.example
+++ b/dracut.conf.d/suse.conf.example
@@ -7,7 +7,7 @@
 hostonly="yes"
 hostonly_cmdline="yes"
 
-compress="zstd"
+compress="zstd -3 -T0 -q"
 
 i18n_vars="/etc/sysconfig/language:RC_LANG-LANG,RC_LC_ALL-LC_ALL /etc/sysconfig/console:CONSOLE_UNICODEMAP-FONT_UNIMAP,CONSOLE_FONT-FONT,CONSOLE_SCREENMAP-FONT_MAP /etc/sysconfig/keyboard:KEYTABLE-KEYMAP"
 omit_drivers+=" i2o_scsi "

--- a/dracut.conf.d/suse.conf.example
+++ b/dracut.conf.d/suse.conf.example
@@ -7,7 +7,7 @@
 hostonly="yes"
 hostonly_cmdline="yes"
 
-compress="xz -0 --check=crc32 --memlimit-compress=50%"
+compress="zstd"
 
 i18n_vars="/etc/sysconfig/language:RC_LANG-LANG,RC_LC_ALL-LC_ALL /etc/sysconfig/console:CONSOLE_UNICODEMAP-FONT_UNIMAP,CONSOLE_FONT-FONT,CONSOLE_SCREENMAP-FONT_MAP /etc/sysconfig/keyboard:KEYTABLE-KEYMAP"
 omit_drivers+=" i2o_scsi "

--- a/dracut.sh
+++ b/dracut.sh
@@ -2398,6 +2398,11 @@ case $compress in
         ;;
 esac
 
+if [[ $compress == $DRACUT_COMPRESS_ZSTD* ]] && ! check_kernel_config CONFIG_RD_ZSTD; then
+    dwarn "dracut: kernel has no zstd support compiled in."
+    compress="cat"
+fi
+
 if ! (
     umask 077
     cd "$initdir"

--- a/suse/dracut.spec
+++ b/suse/dracut.spec
@@ -53,7 +53,8 @@ Requires:       systemd >= 219
 Requires:       systemd-sysvinit
 Requires:       udev > 166
 Requires:       util-linux >= 2.21
-Requires:       xz
+Recommends:     xz
+Requires:       zstd
 # We use 'btrfs fi usage' that was not present before
 Conflicts:      btrfsprogs < 3.18
 # suse-module-tools >= 16.0.3 is prepared for the removal of mkinitrd-suse.sh


### PR DESCRIPTION
This pull request sets zstd as default compression.

Reference: jsc#SLE-20248

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
