### PR TITLE
fix(suse): add 60-io-scheduler.rules (bsc1188713)

### DIFF
--- a/modules.d/99suse/module-setup.sh
+++ b/modules.d/99suse/module-setup.sh
@@ -5,4 +5,7 @@
 
 install() {
     inst_hook cmdline 99 "$moddir/parse-suse-initrd.sh"
+
+    inst_rules \
+    60-io-scheduler.rules
 }


### PR DESCRIPTION
(cherry picked from commit 9e32d35cb8209b811c9cfd59bf0a1677edf91567)

This pull request changes...

## Changes

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
