### PR TITLE
fix(90kernel-modules): add isp1760 USB controller

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -87,6 +87,7 @@ installkernel() {
                 "=drivers/usb/dwc2" \
                 "=drivers/usb/dwc3" \
                 "=drivers/usb/host" \
+                "=drivers/usb/isp1760" \
                 "=drivers/usb/misc" \
                 "=drivers/usb/musb" \
                 "=drivers/usb/phy" \


### PR DESCRIPTION
## Changes
This is a cherry pick from upstream commit 15398458685d376fef56b1bf6fe09ae7c68324c1 to allow to boot from USB (isp1760) on some aarch64 systems.

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
