### PR TITLE
fix(systemd-udevd): make collect optional (bsc#1177870)

### DIFF
--- a/modules.d/95dasd_rules/module-setup.sh
+++ b/modules.d/95dasd_rules/module-setup.sh
@@ -26,7 +26,6 @@ check() {
     local found=0
     local bdev
     [ "$_arch" = "s390" -o "$_arch" = "s390x" ] || return 1
-    require_binaries /usr/lib/udev/collect || return 1
 
     [[ $hostonly ]] || [[ $mount_needs ]] && {
         for bdev in /sys/block/*; do
@@ -50,7 +49,7 @@ depends() {
 
 # called by dracut
 install() {
-    inst_multiple /usr/lib/udev/collect
+    inst_multiple -o /usr/lib/udev/collect
     inst_hook cmdline 30 "$moddir/parse-dasd.sh"
     if [[ $hostonly_cmdline == "yes" ]]; then
         local _dasd

--- a/modules.d/95qeth_rules/module-setup.sh
+++ b/modules.d/95qeth_rules/module-setup.sh
@@ -5,7 +5,6 @@ check() {
     local _arch=${DRACUT_ARCH:-$(uname -m)}
     local _online=0
     [ "$_arch" = "s390" -o "$_arch" = "s390x" ] || return 1
-    require_binaries /usr/lib/udev/collect || return 1
     dracut_module_included network || return 1
 
     [[ $hostonly ]] && {
@@ -55,5 +54,5 @@ install() {
         [ -n "$id" ] && inst_rules_qeth "$id"
     done
 
-    inst_simple /usr/lib/udev/collect
+    inst_simple -o /usr/lib/udev/collect
 }

--- a/modules.d/95zfcp_rules/module-setup.sh
+++ b/modules.d/95zfcp_rules/module-setup.sh
@@ -45,7 +45,6 @@ check() {
     local _arch=${DRACUT_ARCH:-$(uname -m)}
     local _ccw
     [ "$_arch" = "s390" -o "$_arch" = "s390x" ] || return 1
-    require_binaries /usr/lib/udev/collect || return 1
 
     [[ $hostonly ]] || [[ $mount_needs ]] && {
         found=0
@@ -66,7 +65,7 @@ depends() {
 
 # called by dracut
 install() {
-    inst_multiple /usr/lib/udev/collect
+    inst_multiple -o /usr/lib/udev/collect
     inst_hook cmdline 30 "$moddir/parse-zfcp.sh"
     if [[ $hostonly_cmdline == "yes" ]]; then
         local _zfcp


### PR DESCRIPTION
/usr/lib/udev/collect has been removed from udev-v246, so make it optional

(cherry picked from commit 3a1a3c37bd68888004f6c216a44b591ba6de3c29)

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
