### PR TITLE
fix(mdraid): allow UUID comparison for more than one UUID (bsc#1192665)

### DIFF
--- a/modules.d/90mdraid/mdraid_start.sh
+++ b/modules.d/90mdraid/mdraid_start.sh
@@ -54,7 +54,7 @@ _md_force_run() {
             _UUID=$(str_replace "$_UUID" ":" "")
 
             # check if we should handle this device
-            strstr " $_MD_UUID " " $_UUID " || continue
+            strstr "$_MD_UUID" "$_UUID" || continue
 
             _md_start "${_md}"
         done


### PR DESCRIPTION
If the system provides more than one UUID, the _MD_UUID var
contains a line break after each UUID. Therefore the strstr
function could not find any UUID, caused by the additional
spaces provided to the function.

Furthermore this could lead to a boot interruption, because
the start of a degraded raid1 won't be executed. So, manual
interaction is necessary.

(cherry picked from commit d364ce8334fef96f48492bd0fb3b7deac37bbb66)

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
