### PR TITLE
feat: ease decryption setup with TPM2 or FIDO2

### DIFF
--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -24,6 +24,9 @@ depends() {
         if grep -q "tpm2-device=" "$dracutsysrootdir"/etc/crypttab; then
             deps+=" tpm2-tss"
         fi
+        if grep -q -e "fido2-device=" -e "fido2-cid=" "$dracutsysrootdir"/etc/crypttab; then
+            deps+=" fido2"
+        fi
     fi
     echo "$deps"
     return 0

--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -18,7 +18,14 @@ check() {
 
 # called by dracut
 depends() {
-    echo dm rootfs-block
+    local deps
+    deps="dm rootfs-block"
+    if [[ $hostonly && -f "$dracutsysrootdir"/etc/crypttab ]]; then
+        if grep -q "tpm2-device=" "$dracutsysrootdir"/etc/crypttab; then
+            deps+=" tpm2-tss"
+        fi
+    fi
+    echo "$deps"
     return 0
 }
 

--- a/modules.d/91fido2/module-setup.sh
+++ b/modules.d/91fido2/module-setup.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# This file is part of dracut.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Prerequisite check(s) for module.
+check() {
+    # Return 255 to only include the module, if another module requires it.
+    return 255
+}
+
+# Module dependency requirements.
+depends() {
+    # This module has external dependency on other module(s).
+    echo systemd-udevd
+    # Return 0 to include the dependent module(s) in the initramfs.
+    return 0
+}
+
+# Install the required file(s) and directories for the module in the initramfs.
+install() {
+    # Install required libraries.
+    _arch=${DRACUT_ARCH:-$(uname -m)}
+    inst_libdir_file \
+        {"tls/$_arch/",tls/,"$_arch/",}"libfido2.so.*" \
+        {"tls/$_arch/",tls/,"$_arch/",}"libcryptsetup.so.*" \
+        {"tls/$_arch/",tls/,"$_arch/",}"libcbor.so.*" \
+        {"tls/$_arch/",tls/,"$_arch/",}"libhidapi-hidraw.so.*"
+}

--- a/pkgbuild/dracut.spec
+++ b/pkgbuild/dracut.spec
@@ -372,6 +372,7 @@ echo 'dracut_rescue_image="yes"' > $RPM_BUILD_ROOT%{dracutlibdir}/dracut.conf.d/
 %{dracutlibdir}/modules.d/90qemu
 %{dracutlibdir}/modules.d/91crypt-gpg
 %{dracutlibdir}/modules.d/91crypt-loop
+%{dracutlibdir}/modules.d/91fido2
 %{dracutlibdir}/modules.d/91tpm2-tss
 %{dracutlibdir}/modules.d/95debug
 %{dracutlibdir}/modules.d/95fstab-sys


### PR DESCRIPTION
This pull request makes it easy to configure disk decryption using TPM2 or FIDO2 within an unencrypted boot partition scenario.

See: https://en.opensuse.org/SDB:LUKS2,_TPM2_and_FIDO2

Reference: jsc#SLE-21070

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
