### PR TITLE
chore(suse): add fido2 module

### DIFF
--- a/suse/dracut.spec
+++ b/suse/dracut.spec
@@ -368,6 +368,7 @@ fi
 %{dracutlibdir}/modules.d/90qemu-net
 %{dracutlibdir}/modules.d/91crypt-gpg
 %{dracutlibdir}/modules.d/91crypt-loop
+%{dracutlibdir}/modules.d/91fido2
 %{dracutlibdir}/modules.d/91tpm2-tss
 %{dracutlibdir}/modules.d/91zipl
 %{dracutlibdir}/modules.d/95cifs


### PR DESCRIPTION
This pull request adds the fido2 module to the suse spec file.

Reference: jsc#SLE-21070

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
