### PR TITLE
fix(fips): missing value of _vmname variable (bsc#1193267)

### DIFF
--- a/modules.d/01fips/fips.sh
+++ b/modules.d/01fips/fips.sh
@@ -94,10 +94,7 @@ nonfatal_modprobe() {
         done
 }
 
-fips_load_crypto() {
-    local _k
-    local _v
-    local _module
+get_vmname() {
     local _vmname
 
     case "$(uname -m)" in
@@ -117,6 +114,17 @@ fips_load_crypto() {
         _vmname=vmlinuz
         ;;
     esac
+
+    echo "$_vmname"
+}
+
+fips_load_crypto() {
+    local _k
+    local _v
+    local _module
+    local _vmname
+
+    _vmname=$(get_vmname)
 
     KERNEL=$(uname -r)
 
@@ -168,6 +176,9 @@ fips_load_crypto() {
 do_fips() {
     local _v
     local _module
+    local _vmname
+
+    _vmname=$(get_vmname)
 
     KERNEL=$(uname -r)
 


### PR DESCRIPTION
The variable `_vmname` is a local variable within the `fips_load_crypto` function,
but the `do_fips` function tries to use it as well, so it's always uninitialized
within it.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it