### PR TITLE
Suse/055

### DIFF
--- a/modules.d/90multipath/module-setup.sh
+++ b/modules.d/90multipath/module-setup.sh
@@ -41,11 +41,9 @@ depends() {
 
 # called by dracut
 cmdline() {
-    for m in scsi_dh_alua scsi_dh_emc scsi_dh_rdac dm_multipath; do
-        if grep -m 1 -q "$m" /proc/modules; then
-            printf 'rd.driver.pre=%s ' "$m"
-        fi
-    done
+    if grep -m 1 -q dm_multipath /proc/modules; then
+        printf 'rd.driver.pre=%s ' dm_multipath
+    fi
 }
 
 # called by dracut

--- a/modules.d/90multipath/multipathd-configure.service
+++ b/modules.d/90multipath/multipathd-configure.service
@@ -1,8 +1,6 @@
 [Unit]
 Description=Device-Mapper Multipath Default Configuration
-Before=iscsi.service iscsid.service lvm2-activation-early.service
-Wants=systemd-udev-trigger.service systemd-udev-settle.service local-fs-pre.target
-After=systemd-udev-trigger.service systemd-udev-settle.service
+Before=lvm2-activation-early.service
 Before=local-fs-pre.target multipathd.service
 DefaultDependencies=no
 Conflicts=shutdown.target

--- a/modules.d/90multipath/multipathd.service
+++ b/modules.d/90multipath/multipathd.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Device-Mapper Multipath Device Controller
-Before=iscsi.service iscsid.service lvm2-activation-early.service
+Before=lvm2-activation-early.service
 Before=local-fs-pre.target blk-availability.service shutdown.target
 Wants=systemd-udevd-kernel.socket
 After=systemd-udevd-kernel.socket

--- a/modules.d/90multipath/multipathd.service
+++ b/modules.d/90multipath/multipathd.service
@@ -1,9 +1,10 @@
 [Unit]
 Description=Device-Mapper Multipath Device Controller
 Before=iscsi.service iscsid.service lvm2-activation-early.service
-Wants=systemd-udev-trigger.service systemd-udev-settle.service local-fs-pre.target
-After=systemd-udev-trigger.service systemd-udev-settle.service
+Wants=local-fs-pre.target
 Before=local-fs-pre.target
+Wants=systemd-udevd-kernel.socket
+After=systemd-udevd-kernel.socket
 Before=initrd-cleanup.service
 DefaultDependencies=no
 Conflicts=shutdown.target

--- a/modules.d/90multipath/multipathd.service
+++ b/modules.d/90multipath/multipathd.service
@@ -1,10 +1,10 @@
 [Unit]
 Description=Device-Mapper Multipath Device Controller
 Before=iscsi.service iscsid.service lvm2-activation-early.service
-Wants=local-fs-pre.target
-Before=local-fs-pre.target
+Before=local-fs-pre.target blk-availability.service shutdown.target
 Wants=systemd-udevd-kernel.socket
 After=systemd-udevd-kernel.socket
+After=multipathd.socket systemd-remount-fs.service
 Before=initrd-cleanup.service
 DefaultDependencies=no
 Conflicts=shutdown.target
@@ -13,13 +13,15 @@ ConditionKernelCommandLine=!nompath
 ConditionKernelCommandLine=!rd.multipath=0
 ConditionKernelCommandLine=!rd_NO_MULTIPATH
 ConditionKernelCommandLine=!multipath=off
+ConditionVirtualization=!container
 
 [Service]
 Type=simple
 ExecStartPre=-/sbin/modprobe dm-multipath
-ExecStart=/sbin/multipathd -s -d
+ExecStart=/sbin/multipathd -d -s
 ExecReload=/sbin/multipathd reconfigure
-ExecStop=/sbin/multipathd shutdown
+TasksMax=infinity
 
 [Install]
 WantedBy=sysinit.target
+Also=multipathd.socket


### PR DESCRIPTION
This is upstream https://github.com/dracutdevs/dracut/pull/1664.
I'd very much like to have this in SLE15-SP4 beta ASAP.

## Changes

## Checklist
- [ x] I have tested it locally
- [ x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
 * systemd warning about deprecated dependency on `systemd-udev-settle` 
 * eliminate inconsistencies between multipathd.service shipped in multipath-tools and dracut

1881bea is from https://github.com/bmarzins/dracut/commit/edaa7e8 (note that all the mpathconf-related stuff comes from Red Hat and is unused under SUSE). It's not strictly necessary because d2c6999 would stop installing this service anyway.
