### PR TITLE
fix(dracut.spec): require util-linux-systemd (bsc#1194162)

### DIFF
--- a/suse/dracut.spec
+++ b/suse/dracut.spec
@@ -61,6 +61,7 @@ Requires:       systemd >= 219
 Requires:       systemd-sysvinit
 Requires:       udev > 166
 Requires:       util-linux >= 2.21
+Requires:       util-linux-systemd >= 2.36.2
 Recommends:     xz
 Requires:       zstd
 # We use 'btrfs fi usage' that was not present before


### PR DESCRIPTION
`findmnt` and `lsblk` were moved from `util-linux` to `util-linux-systemd` since version 2.36.2.

See https://build.opensuse.org/package/view_file/Base:System/util-linux-systemd/util-linux.changes?expand=1