### PR TITLE
fix(dracut.spec): require util-linux-systemd (bsc#1194162) (backport to 049)

### DIFF
--- a/suse/dracut.spec
+++ b/suse/dracut.spec
@@ -54,6 +54,7 @@ Requires:       systemd >= 219
 Requires:       systemd-sysvinit
 Requires:       udev > 166
 Requires:       util-linux >= 2.21
+Requires:       util-linux-systemd >= 2.36.2
 Requires:       xz
 # We use 'btrfs fi usage' that was not present before
 Conflicts:      btrfsprogs < 3.18


### PR DESCRIPTION
`findmnt` and `lsblk` were moved from `util-linux` to `util-linux-systemd` since version 2.36.2.

See https://build.opensuse.org/package/view_file/Base:System/util-linux-systemd/util-linux.changes?expand=1