### PR TITLE
fix(dracut.spec): change util-linux-systemd version for SLE15-SP2 (049)

### DIFF
--- a/suse/dracut.spec
+++ b/suse/dracut.spec
@@ -54,7 +54,7 @@ Requires:       systemd >= 219
 Requires:       systemd-sysvinit
 Requires:       udev > 166
 Requires:       util-linux >= 2.21
-Requires:       util-linux-systemd >= 2.36.2
+Requires:       util-linux-systemd >= 2.33.2
 Requires:       xz
 # We use 'btrfs fi usage' that was not present before
 Conflicts:      btrfsprogs < 3.18


### PR DESCRIPTION
dracut-049 is on SLE15-SP2 and SP3, but the maximum version available
for util-linux-systemd in SP2 is 2.33.2, so, although findmnt and lsblk
were available in util-linux on SP2, we have to set the require anyway
to fix SP3.