### PR TITLE
fix(dracut-initramfs-restore.sh): add test for SUSE initrd name (bsc#1194570)

### DIFF
--- a/dracut-initramfs-restore.sh
+++ b/dracut-initramfs-restore.sh
@@ -24,15 +24,14 @@ elif [[ -d /boot/loader/entries || -L /boot/loader/entries ]] \
     && [[ $MACHINE_ID ]] \
     && [[ -d /boot/${MACHINE_ID} || -L /boot/${MACHINE_ID} ]]; then
     IMG="/boot/${MACHINE_ID}/${KERNEL_VERSION}/initrd"
-elif [[ -f /boot/initramfs-${KERNEL_VERSION}.img ]]; then
-    IMG="/boot/initramfs-${KERNEL_VERSION}.img"
+elif [[ -f /boot/initrd-${KERNEL_VERSION} ]]; then
+    IMG="/boot/initrd-${KERNEL_VERSION}"
 elif [[ -f /lib/modules/${KERNEL_VERSION}/initrd ]]; then
     IMG="/lib/modules/${KERNEL_VERSION}/initrd"
 else
     echo "No initramfs image found to restore!"
     exit 1
 fi
-[[ -f $IMG ]] || IMG="/boot/initrd-${KERNEL_VERSION}"
 
 cd /run/initramfs
 


### PR DESCRIPTION
dracut-shutdown.service not executed because the dracut-initramfs-restore script
does not contain a valid test for the initrd name used in SUSE.