### PR TITLE
fix(ifcfg): add missing test for wicked DHCP lease file (bsc#1193518) (049)

### DIFF
--- a/modules.d/45ifcfg/write-ifcfg.sh
+++ b/modules.d/45ifcfg/write-ifcfg.sh
@@ -168,14 +168,14 @@ for netup in /tmp/net.*.did-setup ; do
         echo "NETBOOT=yes"
         echo "UUID=\"$uuid\""
         strstr "$(ip -6 addr show dev $netif)" 'inet6' && echo "IPV6INIT=yes"
-        if [ -f /tmp/dhclient.$netif.lease ]; then
+        if [ -f /tmp/dhclient.$netif.lease ] || [ -n "$(ls "/tmp/leaseinfo.${netif}"* 2> /dev/null)" ]; then
             [ -f /tmp/dhclient.$netif.dhcpopts ] && . /tmp/dhclient.$netif.dhcpopts
             if [ -f /tmp/net.$netif.has_ibft_config ]; then
                 echo "BOOTPROTO=ibft"
             else
                 echo "BOOTPROTO=dhcp"
             fi
-            cp /tmp/dhclient.$netif.lease /tmp/ifcfg-leases/dhclient-$uuid-$netif.lease
+            cp /tmp/dhclient.$netif.lease /tmp/ifcfg-leases/dhclient-$uuid-$netif.lease 2>/dev/null
         else
             # If we've booted with static ip= lines, the override file is there
             [ -e /tmp/net.$netif.override ] && . /tmp/net.$netif.override


### PR DESCRIPTION
For wicked, the DHCP lease is saved in a file with a [different name](https://github.com/openSUSE/dracut/blob/SUSE/049/modules.d/35network-legacy/ifup.sh#L172) than the one generated by dhclient.

This wicked lease file is generated using SUSE specific code (not upstream), so for 049 it makes sense to just add a test condition to solve this issue.

For 055 there is a new network-wicked module. We must evaluate if we just add this fix for now, or wait until network-wicked also implements all the functionality of the network-legacy module, so ifcfg could be implemented accordingly so as not to rely only on dhclient, NetworkManager and other RH specific stuff like ccw_init.