### PR TITLE
fix(install): handle builtin modules (bsc#1194716)

### DIFF
--- a/install/dracut-install.c
+++ b/install/dracut-install.c
@@ -1352,6 +1352,13 @@ static int install_module(struct kmod_module *mod)
         const char *name = NULL;
 
         name = kmod_module_get_name(mod);
+
+        path = kmod_module_get_path(mod);
+        if (!path) {
+                log_debug("dracut_install '%s' is a builtin kernel module", name);
+                return 0;
+        }
+
         if (arg_mod_filter_noname && (regexec(&mod_filter_noname, name, 0, NULL, 0) == 0)) {
                 log_debug("dracut_install '%s' is excluded", name);
                 return 0;
@@ -1361,10 +1368,6 @@ static int install_module(struct kmod_module *mod)
                 log_debug("dracut_install '%s' not hostonly", name);
                 return 0;
         }
-
-        path = kmod_module_get_path(mod);
-        if (!path)
-                return -ENOENT;
 
         if (check_hashmap(items_failed, path))
                 return -1;


### PR DESCRIPTION
If a `kmod_module` is missing the `path`, it is `builtin`.

(cherry picked from commit 2536a9eaffbc9cc14c85579a2f537d3f3a1d5659)

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes bsc#1194716
