### PR TITLE
fix(network-legacy): add wicked as an alternative to arping (bsc#1193670)

### DIFF
--- a/modules.d/35network-legacy/dhclient-script.sh
+++ b/modules.d/35network-legacy/dhclient-script.sh
@@ -187,8 +187,13 @@ case $reason in
                     warn "Duplicate address detected for $new_ip_address while doing dhcp. retrying"
                     exit 1
                 fi
-            else
+            elif command -v arping > /dev/null; then
                 if ! arping -f -q -D -c 2 -I "$netif" "$new_ip_address"; then
+                    warn "Duplicate address detected for $new_ip_address while doing dhcp. retrying"
+                    exit 1
+                fi
+            else
+                if ! wicked arp verify --quiet --count 2 --interval 1000 "$netif" "$new_ip_address"; then
                     warn "Duplicate address detected for $new_ip_address while doing dhcp. retrying"
                     exit 1
                 fi

--- a/modules.d/35network-legacy/ifup.sh
+++ b/modules.d/35network-legacy/ifup.sh
@@ -332,8 +332,13 @@ do_static() {
                     warn "Duplicate address detected for $ip for interface $netif."
                     return 1
                 fi
-            else
+            elif command -v arping > /dev/null; then
                 if ! arping -f -q -D -c 2 -I "$netif" "$ip"; then
+                    warn "Duplicate address detected for $ip for interface $netif."
+                    return 1
+                fi
+            else
+                if ! wicked arp verify --quiet --count 2 --interval 1000 "$netif" "$ip"; then
                     warn "Duplicate address detected for $ip for interface $netif."
                     return 1
                 fi

--- a/modules.d/35network-legacy/module-setup.sh
+++ b/modules.d/35network-legacy/module-setup.sh
@@ -33,7 +33,9 @@ install() {
     inst_multiple ip dhclient sed awk grep pgrep tr expr
 
     inst_multiple -o arping arping2
-    strstr "$(arping 2>&1)" "ARPing 2" && mv "$initdir/bin/arping" "$initdir/bin/arping2"
+    if command -v arping > /dev/null; then
+        strstr "$(arping 2>&1)" "ARPing 2" && mv "$initdir/bin/arping" "$initdir/bin/arping2"
+    fi
     inst_multiple -o wicked
     inst_multiple -o ping ping6
     inst_multiple -o teamd teamdctl teamnl

--- a/modules.d/40network/net-lib.sh
+++ b/modules.d/40network/net-lib.sh
@@ -188,8 +188,10 @@ setup_net() {
     if [ "$layer2" != "0" ] && [ -n "$dest" ] && ! strstr "$dest" ":"; then
         if command -v arping2 > /dev/null; then
             arping2 -q -C 1 -c 60 -I "$netif" "$dest" || info "Resolving $dest via ARP on $netif failed"
-        else
+        elif command -v arping > /dev/null; then
             arping -q -f -w 60 -I "$netif" "$dest" || info "Resolving $dest via ARP on $netif failed"
+        elif command -v wicked > /dev/null; then
+            wicked arp ping --quiet --interval 1000 --timeout 60000 "$netif" "$dest" || info "Resolving $dest via ARP on $netif failed"
         fi
     fi
     unset layer2


### PR DESCRIPTION
Add `wicked arp` as an alternative to `arping`.
