### PR TITLE
fix(network-legacy): installation fixes (bsc#1194879) 

### DIFF
--- a/modules.d/35network-legacy/module-setup.sh
+++ b/modules.d/35network-legacy/module-setup.sh
@@ -57,10 +57,14 @@ install() {
     inst_hook cleanup 10 "$moddir/kill-dhclient.sh"
 
     # SUSE specific files
-    inst_multiple /etc/sysconfig/network/ifcfg-*
-    inst_multiple -o /etc/sysconfig/network/ifroute-*
-    inst_simple /etc/sysconfig/network/routes
-    inst_multiple -o /var/lib/wicked/duid.xml /var/lib/wicked/iaid.xml
+    for f in \
+        /etc/sysconfig/network/ifcfg-* \
+        /etc/sysconfig/network/ifroute-* \
+        /etc/sysconfig/network/routes \
+        /var/lib/wicked/duid.xml \
+        /var/lib/wicked/iaid.xml; do
+        [ -e "$f" ] && inst_simple "$f"
+    done
 
     # install all config files for teaming
     unset TEAM_MASTER

--- a/modules.d/35network-legacy/module-setup.sh
+++ b/modules.d/35network-legacy/module-setup.sh
@@ -30,7 +30,8 @@ install() {
         [[ $hostonly ]] && inst_multiple -H -o "${systemdsystemconfdir}/network/*.link"
     fi
 
-    inst_multiple ip dhclient sed awk grep pgrep tr expr
+    inst_multiple ip sed awk grep pgrep tr expr
+    inst_simple -o dhclient
 
     inst_multiple -o arping arping2
     if command -v arping > /dev/null; then


### PR DESCRIPTION
This PR includes 2 fixes related to the network-legacy module:
- Set dhclient as optional.
- Install only existing SUSE specific files.