### PR TITLE
fix(network): consistent use of "$gw" for gateway (backport to 049)

### DIFF
--- a/modules.d/40network/net-lib.sh
+++ b/modules.d/40network/net-lib.sh
@@ -281,7 +281,7 @@ ibft_to_cmdline() {
                 # skip not assigned ip adresses
                 [ "$ip" = "0.0.0.0" ] && continue
                 [ -e ${iface}/gateway ] && gw=$(read a < ${iface}/gateway; echo $a)
-                [ "$gateway" = "0.0.0.0" ] && unset $gateway
+                [ "$gw" = "0.0.0.0" ] && unset $gw
                 [ -e ${iface}/subnet-mask ] && mask=$(read a < ${iface}/subnet-mask; echo $a)
                 [ -e ${iface}/prefix-len ] && prefix=$(read a < ${iface}/prefix-len; echo $a)
                 [ -e ${iface}/primary-dns ] && dns1=$(read a < ${iface}/primary-dns; echo $a)


### PR DESCRIPTION
Replace wrong use of $gateway with $gw.

Signed-off-by: Martin Wilck <mwilck@suse.com>

