### PR TITLE
Revert "fix(multipath): don't force-load SCSI device handlers"

### DIFF
--- a/modules.d/90multipath/module-setup.sh
+++ b/modules.d/90multipath/module-setup.sh
@@ -41,9 +41,11 @@ depends() {
 
 # called by dracut
 cmdline() {
-    if grep -m 1 -q dm_multipath /proc/modules; then
-        printf 'rd.driver.pre=%s ' dm_multipath
-    fi
+    for m in scsi_dh_alua scsi_dh_emc scsi_dh_rdac dm_multipath; do
+        if grep -m 1 -q "$m" /proc/modules; then
+            printf 'rd.driver.pre=%s ' "$m"
+        fi
+    done
 }
 
 # called by dracut


### PR DESCRIPTION
This reverts commit 466d45be4838fee9ad75b629a927ff84cf508cf0.

This commit was broken. It is still necessary to load the SCSI
device handlers early. While there may be better solutions in the long
run, just revert this commit for now.

See https://github.com/dracutdevs/dracut/pull/1664#issuecomment-1019832784 for an in-depth explanation.

