### PR TITLE
fix(dracut-functions.sh): ip route parsing

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -762,13 +762,29 @@ btrfs_devs() {
 iface_for_remote_addr() {
     # shellcheck disable=SC2046
     set -- $(ip -o route get to "$1")
-    echo "$3"
+    while [ $# -gt 0 ]; do
+        case $1 in
+            dev)
+                echo "$2"
+                return
+                ;;
+        esac
+        shift
+    done
 }
 
 local_addr_for_remote_addr() {
     # shellcheck disable=SC2046
     set -- $(ip -o route get to "$1")
-    echo "$5"
+    while [ $# -gt 0 ]; do
+        case $1 in
+            src)
+                echo "$2"
+                return
+                ;;
+        esac
+        shift
+    done
 }
 
 peer_for_addr() {


### PR DESCRIPTION
The code for determining local interface and address works
only for peers that are reachable in a single hop.

This is parsed correctly:
192.168.110.1 dev br0 src 192.168.110.160 uid 0 \    cache

But this isn't:
192.168.1.4 via 192.168.110.1 dev br0 src 192.168.110.160 uid 0 \    cache

Fix it.

Fixes: ceca74cc ("dracut-functions: add ip_params_for_remote_addr() helper")
