### PR TITLE
WIP: network-wicked

### DIFF
--- a/modules.d/35network-wicked/module-setup.sh
+++ b/modules.d/35network-wicked/module-setup.sh
@@ -1,37 +1,67 @@
 #!/bin/bash
+# This file is part of dracut.
+# SPDX-License-Identifier: GPL-2.0-or-later
 
-# called by dracut
+#
+# WARNING: THIS IS A WIP MODULE
+#
+# For speed up testing, control how this module is going to work using the
+# rd.net.wickedonly command line parameter:
+#   - If not present, use legacy ifup and net-genrules
+#   - If present, use just wicked
+#
+
+# Prerequisite check(s) for module.
 check() {
-    require_binaries wicked || return 1
 
-    # do not add this module by default
+    # If the binary(s) requirements are not fulfilled the module can't be installed.
+    require_binaries ip \
+        wicked \
+        wickedd \
+        wickedd-nanny \
+        || return 1
+    require_any_binary /usr/{lib,libexec}/wicked/bin/wickedd-auto4 || return 1
+    require_any_binary /usr/{lib,libexec}/wicked/bin/wickedd-dhcp4 || return 1
+    require_any_binary /usr/{lib,libexec}/wicked/bin/wickedd-dhcp6 || return 1
+
+    # Do not add this module by default.
     return 255
 }
 
-# called by dracut
+# Module dependency requirements.
 depends() {
-    echo systemd dbus
+
+    # This module has external dependency on other module(s).
+    echo dbus kernel-network-modules systemd
+
+    # Return 0 to include the dependent module(s) in the initramfs.
     return 0
+
 }
 
-# called by dracut
-installkernel() {
-    return 0
-}
-
-# called by dracut
+# Install the required file(s) and directories for the module.
 install() {
-    local -a wicked_units
 
+    # Scripts.
+    # TODO: do we need this ifup? (already reworked from 35network-legacy/ifup.sh)
+    inst_script "$moddir/wicked-ifup.sh" "/sbin/ifup"
+
+    # Hooks.
+    # TODO: scripts needed to parse arguments for ifup (from 35network-legacy)
+    inst_hook cmdline 92 "$moddir/wicked-parse-ibft.sh"
+    inst_hook cmdline 95 "$moddir/wicked-parse-vlan.sh"
+    inst_hook cmdline 96 "$moddir/wicked-parse-bond.sh"
+    inst_hook cmdline 96 "$moddir/wicked-parse-team.sh"
+    inst_hook cmdline 97 "$moddir/wicked-parse-bridge.sh"
+    inst_hook cmdline 98 "$moddir/wicked-parse-ip-opts.sh"
+    inst_hook cmdline 99 "$moddir/wicked-parse-ifname.sh"
+    # TODO: IIUC we can get rid of wicked show-config and avoid the cmdline hook
     inst_hook cmdline 99 "$moddir/wicked-config.sh"
-
-    # Seems to not execute if in initqueue/settled
+    # TODO: do we need to create udev rules like 35network-legacy/net-genrules.sh?
+    inst_hook pre-udev 60 "$moddir/wicked-net-genrules.sh"
     inst_hook pre-udev 99 "$moddir/wicked-run.sh"
 
-    # even with wicked configuring the interface, ip is useful
-    inst_multiple ip
-
-    inst_dir /etc/wicked/extensions
+    # Create wicked related directories.
     inst_dir /usr/share/wicked/schema
     if [ -d /usr/lib/wicked/bin ]; then
         inst_dir /usr/lib/wicked/bin
@@ -42,35 +72,123 @@ install() {
     fi
     inst_dir /var/lib/wicked
 
-    inst_multiple "/etc/wicked/*.xml"
-    inst_multiple "/etc/wicked/extensions/*"
+    # TODO: do we need the wicked.service?
+    inst_multiple -o \
+        "/usr/share/wicked/schema/*" \
+        /var/lib/wicked/duid.xml \
+        /var/lib/wicked/iaid.xml \
+        "$dbussystemservices"/org.opensuse.Network.AUTO4.service \
+        "$dbussystemservices"/org.opensuse.Network.DHCP4.service \
+        "$dbussystemservices"/org.opensuse.Network.DHCP6.service \
+        "$dbussystemservices"/org.opensuse.Network.Nanny.service \
+        "$systemdsystemunitdir"/wicked.service \
+        "$systemdsystemunitdir"/wickedd.service \
+        "$systemdsystemunitdir"/wickedd-auto4.service \
+        "$systemdsystemunitdir"/wickedd-dhcp4.service \
+        "$systemdsystemunitdir"/wickedd-dhcp6.service \
+        "$systemdsystemunitdir"/wickedd-nanny.service \
+        "$systemdsystemunitdir/wickedd-pppd@.service" \
+        wicked wickedd wickedd-nanny pppd \
+        teamd teamdctl teamnl
+
+    inst_multiple -o \
+        ip ping ping6 sed expr
+
     if [ -f /etc/dbus-1/system.d/org.opensuse.Network.conf ]; then
         inst_multiple "/etc/dbus-1/system.d/org.opensuse.Network*"
     elif [ -f /usr/share/dbus-1/system.d/org.opensuse.Network.conf ]; then
         inst_multiple "/usr/share/dbus-1/system.d/org.opensuse.Network*"
     fi
-    inst_multiple "/usr/share/wicked/schema/*"
-    inst_multiple "/usr/sbin/wicked*"
 
-    wicked_units=(
-        "$systemdsystemunitdir"/wickedd.service
-        "$systemdsystemunitdir"/wickedd-auto4.service
-        "$systemdsystemunitdir"/wickedd-dhcp4.service
-        "$systemdsystemunitdir"/wickedd-dhcp6.service
-        "$systemdsystemunitdir"/wickedd-nanny.service
-    )
+    # Enable systemd type units.
+    # TODO: do we need the wicked.service?
+    local i
+    for i in \
+        wicked.service \
+        wickedd.service \
+        wickedd-auto4.service \
+        wickedd-dhcp4.service \
+        wickedd-dhcp6.service \
+        wickedd-nanny.service \
+        wickedd-pppd@.service; do
+        $SYSTEMCTL -q --root "$initdir" enable "$i"
+    done
 
-    inst_multiple "${wicked_units[@]}"
+    # Install the hosts local user configurations if enabled.
+    if [[ $hostonly ]]; then
+        inst_dir /etc/wicked/extensions
 
-    for unit in "${wicked_units[@]}"; do
-        sed -i 's/^After=.*/After=dbus.service/g' "$initdir/$unit"
-        sed -i 's/^Before=\(.*\)/Before=\1 dracut-pre-udev.service/g' "$initdir/$unit"
-        sed -i 's/^Wants=\(.*\)/Wants=\1 dbus.service/g' "$initdir/$unit"
+        local wickeddbusconfdir
+        wickeddbusconfdir="$dbusconfdir"
+        if [ ! -f "$wickeddbusconfdir/org.opensuse.Network.conf" ]; then
+            if [ -f /etc/dbus-1/system.d/org.opensuse.Network.conf ]; then
+                wickeddbusconfdir="/etc/dbus-1/system.d"
+            elif [ -f /usr/share/dbus-1/system.d/org.opensuse.Network.conf ]; then
+                wickeddbusconfdir="/usr/share/dbus-1/system.d"
+            fi
+        fi
+
+        # TODO: do we need the wicked.service?
+        inst_multiple -H -o \
+            "/etc/wicked/*.xml" \
+            "/etc/wicked/extensions/*" \
+            "$wickeddbusconfdir"/org.opensuse.Network.conf \
+            "$wickeddbusconfdir"/org.opensuse.Network.AUTO4.conf \
+            "$wickeddbusconfdir"/org.opensuse.Network.DHCP4.conf \
+            "$wickeddbusconfdir"/org.opensuse.Network.DHCP6.conf \
+            "$wickeddbusconfdir"/org.opensuse.Network.Nanny.conf \
+            "$systemdsystemconfdir"/wicked.service \
+            "$systemdsystemconfdir/wicked.service/*.conf" \
+            "$systemdsystemconfdir/wicked@.service" \
+            "$systemdsystemconfdir/wicked@.service/*.conf" \
+            "$systemdsystemconfdir"/wickedd.service \
+            "$systemdsystemconfdir/wickedd.service/*.conf" \
+            "$systemdsystemconfdir"/wickedd-auto4.service \
+            "$systemdsystemconfdir/wickedd-auto4.service/*.conf" \
+            "$systemdsystemconfdir"/wickedd-dhcp4.service \
+            "$systemdsystemconfdir/wickedd-dhcp4.service/*.conf" \
+            "$systemdsystemconfdir"/wickedd-dhcp6.service \
+            "$systemdsystemconfdir/wickedd-dhcp6.service/*.conf" \
+            "$systemdsystemconfdir"/wickedd-nanny.service \
+            "$systemdsystemconfdir/wickedd-nanny.service/*.conf" \
+            "$systemdsystemconfdir/wickedd-pppd@.service" \
+            "$systemdsystemconfdir/wickedd-pppd@.service.d/*.conf" \
+            /etc/libnl/classid
+
+        if [ -f /etc/dbus-1/system.d/org.opensuse.Network.conf ]; then
+            inst_multiple "/etc/dbus-1/system.d/org.opensuse.Network*"
+        elif [ -f /usr/share/dbus-1/system.d/org.opensuse.Network.conf ]; then
+            inst_multiple "/usr/share/dbus-1/system.d/org.opensuse.Network*"
+        fi
+
+        # SUSE specific configuration.
+        # TODO: does it make sense to copy the ifcfg files from running system?
+        inst_multiple -o \
+            /etc/sysconfig/network/config \
+            /etc/sysconfig/network/dhcp \
+            /etc/sysconfig/network/ifcfg-* \
+            /etc/sysconfig/network/ifroute-* \
+            /etc/sysconfig/network/routes
+    fi
+
+    # Modify systemd units.
+    # After= must be reset to dbus.service only, so drop-ins don't work here.
+    for i in \
+        wickedd.service \
+        wickedd-auto4.service \
+        wickedd-dhcp4.service \
+        wickedd-dhcp6.service \
+        wickedd-nanny.service; do
+        sed -i 's/^After=.*/After=dbus.service/g' "$initdir/$systemdsystemunitdir/$i"
+        sed -i 's/^Before=\(.*\)/Before=\1 dracut-pre-udev.service/g' "$initdir/$systemdsystemunitdir/$i"
+        sed -i 's/^Wants=\(.*\)/Wants=\1 dbus.service/g' "$initdir/$systemdsystemunitdir/$i"
         # shellcheck disable=SC1004
         sed -i -e \
             '/^\[Unit\]/aDefaultDependencies=no\
             Conflicts=shutdown.target\
             Before=shutdown.target' \
-            "$initdir/$unit"
+            "$initdir/$systemdsystemunitdir/$i"
     done
+
+    dracut_need_initqueue
 }

--- a/modules.d/35network-wicked/wicked-config.sh
+++ b/modules.d/35network-wicked/wicked-config.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+type getargbool > /dev/null 2>&1 || . /lib/dracut-lib.sh
+
+if ! getargbool 0 rd.net.wickedonly; then
+    return
+fi
+
 getcmdline > /tmp/cmdline.$$.conf
 wicked show-config --ifconfig dracut:cmdline:/tmp/cmdline.$$.conf > /tmp/dracut.xml
 rm -f /tmp/cmdline.$$.conf

--- a/modules.d/35network-wicked/wicked-ifup.sh
+++ b/modules.d/35network-wicked/wicked-ifup.sh
@@ -1,0 +1,673 @@
+#!/bin/bash
+# This file is part of dracut.
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# rework from 35network-legacy/ifup.sh
+#
+# $1    network interface
+# $2    optional options:
+#   -m      manual up
+#
+# without $2 means this is for real netroot case
+# or it is for manually bring up network ie. for kdump scp vmcore
+PATH=/usr/sbin:/usr/bin:/sbin:/bin
+
+type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
+type ip_to_var > /dev/null 2>&1 || . /lib/net-lib.sh
+
+if getargbool 0 rd.net.wickedonly; then
+    return
+fi
+
+# get network interface
+[ -z "$1" ] && exit 1
+netif=$1
+
+# loopback is always handled the same way
+if [ "$netif" = "lo" ]; then
+    # systemd probably has already set up lo
+    ip link show dev lo >/dev/null && exit 0
+
+    ip link set lo up
+    ip addr add 127.0.0.1/8 dev lo
+    exit 0
+fi
+
+dhcp_wicked_apply() {
+    unset IPADDR INTERFACE BROADCAST NETWORK PREFIXLEN ROUTES GATEWAYS MTU HOSTNAME DNSDOMAIN DNSSEARCH DNSSERVERS
+    if [ -f "/tmp/leaseinfo.${netif}.dhcp.ipv${1:1:1}" ]; then
+        # shellcheck disable=SC1090
+        . "/tmp/leaseinfo.${netif}.dhcp.ipv${1:1:1}"
+    else
+        warn "DHCP failed";
+        return 1
+    fi
+
+    if [ -z "${IPADDR}" ] || [ -z "${INTERFACE}" ]; then
+           warn "Missing crucial DHCP variables"
+           return 1
+    fi
+
+    # Assign IP address
+    ip "$1" addr add "$IPADDR" ${BROADCAST:+broadcast $BROADCAST} dev "$INTERFACE"
+
+    # Assign provided routes
+    local r route=()
+    if [ -n "${ROUTES}" ]; then
+        for r in ${ROUTES}; do
+            # shellcheck disable=SC2206
+            route=(${r//,/ })
+            [[ ${route[2]} == "0.0.0.0" ]] || gateway=" via ${route[2]}"
+            ip "$1" route add "${route[0]}"/"${route[1]}""$gateway" dev "$INTERFACE"
+        done
+    fi
+
+    # Assign provided routers
+    local g
+    if [ -n "${GATEWAYS}" ]; then
+        for g in ${GATEWAYS}; do
+            ip "$1" route add default via "$g" dev "$INTERFACE" && break
+        done
+    fi
+
+    # Set MTU
+    [ -n "${MTU}" ] && ip "$1" link set mtu "$MTU" dev "$INTERFACE"
+
+    # Setup hostname
+    [ -n "${HOSTNAME}" ] && echo "$HOSTNAME" > /proc/sys/kernel/hostname
+
+    # If nameserver= has not been specified, use what dhcp provides
+    if [ ! -s /tmp/net."$netif".resolv.conf.ipv"${1:1:1}" ]; then
+        if [ -n "${DNSDOMAIN}" ]; then
+            echo "domain ${DNSDOMAIN}" >> /tmp/net."$netif".resolv.conf.ipv"${1:1:1}"
+        fi
+        if [ -n "${DNSSEARCH}" ]; then
+            echo "search ${DNSSEARCH}" >> /tmp/net."$netif".resolv.conf.ipv"${1:1:1}"
+        fi
+        if  [ -n "${DNSSERVERS}" ]; then
+            for s in ${DNSSERVERS}; do
+                echo "nameserver ${s}" >> /tmp/net."$netif".resolv.conf.ipv"${1:1:1}"
+            done
+        fi
+    fi
+    # copy resolv.conf if it doesn't exist yet, modify otherwise
+    if [ -e /tmp/net."$netif".resolv.conf.ipv"${1:1:1}" ] && [ ! -e /etc/resolv.conf ]; then
+        cp -f /tmp/net."$netif".resolv.conf.ipv"${1:1:1}" /etc/resolv.conf
+    else
+        if [ -n "$(sed -n '/^search .*$/p' /etc/resolv.conf)" ]; then
+            sed -i "s/\(^search .*\)$/\1 ${DNSSEARCH}/" /etc/resolv.conf
+        else
+            echo "search ${DNSSEARCH}" >> /etc/resolv.conf
+        fi
+        if  [ -n "${DNSSERVERS}" ]; then
+            for s in ${DNSSERVERS}; do
+                echo "nameserver ${s}" >> /etc/resolv.conf
+            done
+        fi
+    fi
+
+    info "DHCP is finished successfully"
+    return 0
+
+}
+
+dhcp_wicked_read_ifcfg() {
+    unset PREFIXLEN LLADDR MTU REMOTE_IPADDR GATEWAY BOOTPROTO
+
+    if [ ! -e /etc/sysconfig/network/ifcfg-"${netif}" ]; then
+        return 1
+    fi
+
+    # Pull in existing configuration
+    # shellcheck disable=SC1090
+    . /etc/sysconfig/network/ifcfg-"${netif}"
+
+    # The first configuration can be anything
+    # shellcheck disable=SC2034
+    [ -n "$PREFIXLEN" ] && prefix=${PREFIXLEN}
+    # shellcheck disable=SC2034
+    [ -n "$LLADDR" ] && macaddr=${LLADDR}
+    # shellcheck disable=SC2034
+    [ -n "$MTU" ] && mtu=${MTU}
+    # shellcheck disable=SC2034
+    [ -n "$REMOTE_IPADDR" ] && server=${REMOTE_IPADDR}
+    # shellcheck disable=SC2034,SC2153
+    [ -n "$GATEWAY" ] && gw=${GATEWAY}
+    # shellcheck disable=SC2034
+    [ -n "$BOOTPROTO" ] && autoconf=${BOOTPROTO}
+
+    return 0
+}
+
+dhcp_wicked_run() {
+    if ! linkup "$netif"; then
+        warn "Could not bring interface $netif up!"
+        return 1
+    fi
+
+    local wicked_cmd
+    if [ "$1" = "-6" ]; then
+        local ipv6_mode
+        if [ -f "/tmp/net.${netif}.auto6" ]; then
+            ipv6_mode="auto"
+        else
+            ipv6_mode="managed"
+        fi
+        wicked_cmd="wicked test dhcp6 -m $ipv6_mode"
+    else
+        wicked_cmd="wicked test dhcp4"
+    fi
+
+    local timeout
+    timeout=$(getarg rd.net.timeout.dhcp=)
+    if [ -n "$timeout" ]; then
+        wicked_cmd="${wicked_cmd} --timeout ${timeout}"
+    fi
+
+    if dhcp_wicked_read_ifcfg; then
+        [ -n "$macaddr" ] && ip "$1" link set address "$macaddr" dev "$netif"
+        [ -n "$mtu" ] && ip "$1" link set mtu "$mtu" dev "$netif"
+    fi
+
+    ${wicked_cmd} --format leaseinfo --output "/tmp/leaseinfo.${netif}.dhcp.ipv${1:1:1}" --request - "$netif" << EOF
+<request type="lease"/>
+EOF
+    # shellcheck disable=SC2086
+    dhcp_wicked_apply $1 || return $?
+
+    if [ "$1" = "-6" ]; then
+        wait_for_ipv6_dad "$netif"
+    fi
+
+    return 0
+}
+
+do_dhcp() {
+    local _COUNT
+    local _DHCPRETRY
+
+    _COUNT=0
+    _DHCPRETRY=$(getargnum 1 1 1000000000 rd.net.dhcp.retry=)
+
+    if ! iface_has_carrier "$netif"; then
+        warn "No carrier detected on interface $netif"
+        return 1
+    fi
+
+    while [ "$_COUNT" -lt "$_DHCPRETRY" ]; do
+        info "Starting dhcp for interface $netif"
+        dhcp_wicked_run "$@" && return 0
+        _COUNT=$((_COUNT + 1))
+        [ "$_COUNT" -lt "$_DHCPRETRY" ] && sleep 1
+    done
+    warn "dhcp for interface $netif failed"
+    # nuke those files since we failed; we might retry dhcp again if it's e.g. `ip=dhcp,dhcp6`
+    rm -f /tmp/leaseinfo."$netif".*
+    return 1
+}
+
+load_ipv6() {
+    [ -d /proc/sys/net/ipv6 ] && return
+    modprobe ipv6
+    i=0
+    while [ ! -d /proc/sys/net/ipv6 ]; do
+        i=$((i + 1))
+        [ $i -gt 10 ] && break
+        sleep 0.1
+    done
+}
+
+do_ipv6auto() {
+    local ret
+    load_ipv6
+    echo 0 > /proc/sys/net/ipv6/conf/"${netif}"/forwarding
+    echo 1 > /proc/sys/net/ipv6/conf/"${netif}"/accept_ra
+    echo 1 > /proc/sys/net/ipv6/conf/"${netif}"/accept_redirects
+    linkup "$netif"
+    wait_for_ipv6_auto "$netif"
+    ret=$?
+
+    [ -n "$hostname" ] && echo "echo $hostname > /proc/sys/kernel/hostname" > "/tmp/net.${netif}.hostname"
+
+    return "$ret"
+}
+
+do_ipv6link() {
+    local ret
+    load_ipv6
+    echo 0 > /proc/sys/net/ipv6/conf/"${netif}"/forwarding
+    echo 0 > /proc/sys/net/ipv6/conf/"${netif}"/accept_ra
+    echo 0 > /proc/sys/net/ipv6/conf/"${netif}"/accept_redirects
+    linkup "$netif"
+
+    [ -n "$hostname" ] && echo "echo $hostname > /proc/sys/kernel/hostname" > "/tmp/net.${netif}.hostname"
+
+    return "$ret"
+}
+
+# Handle static ip configuration
+do_static() {
+    strglobin "$ip" '*:*:*' && load_ipv6
+
+    if ! iface_has_carrier "$netif"; then
+        warn "No carrier detected on interface $netif"
+        return 1
+    elif ! linkup "$netif"; then
+        warn "Could not bring interface $netif up!"
+        return 1
+    fi
+
+    ip route get "$ip" 2> /dev/null | {
+        read -r a rest
+        if [ "$a" = "local" ]; then
+            warn "Not assigning $ip to interface $netif, cause it is already assigned!"
+            return 1
+        fi
+        return 0
+    } || return 1
+
+    [ -n "$macaddr" ] && ip link set address "$macaddr" dev "$netif"
+    [ -n "$mtu" ] && ip link set mtu "$mtu" dev "$netif"
+    if strglobin "$ip" '*:*:*'; then
+        # note no ip addr flush for ipv6
+        ip addr add "$ip/$mask" ${srv:+peer "$srv"} dev "$netif"
+        echo 0 > /proc/sys/net/ipv6/conf/"${netif}"/forwarding
+        echo 1 > /proc/sys/net/ipv6/conf/"${netif}"/accept_ra
+        echo 1 > /proc/sys/net/ipv6/conf/"${netif}"/accept_redirects
+        wait_for_ipv6_dad "$netif"
+    else
+        if [ -z "$srv" ]; then
+            wicked arp verify --quiet --count 2 --interval 1000 "$netif" "$ip"
+            if [ $? -eq 4 ]; then
+                warn "Duplicate address detected for $ip for interface $netif."
+                return 1
+            fi
+        fi
+        ip addr flush dev "$netif"
+        ip addr add "$ip/$mask" ${srv:+peer "$srv"} brd + dev "$netif"
+    fi
+
+    [ -n "$gw" ] && echo "ip route replace default via '$gw' dev '$netif'" > "/tmp/net.$netif.gw"
+    [ -n "$hostname" ] && echo "echo '$hostname' > /proc/sys/kernel/hostname" > "/tmp/net.$netif.hostname"
+
+    # SUSE specific
+    for ifroute in /etc/sysconfig/network/ifroute-${netif} /etc/sysconfig/network/routes ; do
+        [ -e "${ifroute}" ] || continue
+        # Pull in existing routing configuration
+        # shellcheck disable=SC2162,SC2034
+        read ifr_dest ifr_gw ifr_mask ifr_if < "${ifroute}"
+        [ -z "$ifr_dest" -o -z "$ifr_gw" ] && continue
+        if [ "$ifr_if" = "-" ]; then
+            echo "ip route add ${ifr_dest} via ${ifr_gw}" >> "/tmp/net.$netif.gw"
+        else
+            echo "ip route add ${ifr_dest} via ${ifr_gw} dev ${ifr_if}" >> "/tmp/net.$netif.gw"
+        fi
+    done
+
+    return 0
+}
+
+get_vid() {
+    case "$1" in
+        vlan*)
+            echo "${1#vlan}"
+            ;;
+        *.*)
+            echo "${1##*.}"
+            ;;
+    esac
+}
+
+# check, if we need VLAN's for this interface
+if [ -z "$DO_VLAN_PHY" ] && [ -e "/tmp/vlan.${netif}.phy" ]; then
+    unset DO_VLAN
+    NO_AUTO_DHCP=yes DO_VLAN_PHY=yes ifup "$netif"
+    modprobe -b -q 8021q
+
+    for i in /tmp/vlan.*."${netif}"; do
+        [ -e "$i" ] || continue
+        unset vlanname
+        unset phydevice
+        # shellcheck disable=SC1090
+        . "$i"
+        if [ -n "$vlanname" ]; then
+            linkup "$phydevice"
+            ip link add dev "$vlanname" link "$phydevice" type vlan id "$(get_vid "$vlanname")"
+            ifup "$vlanname"
+        fi
+    done
+    exit 0
+fi
+
+# Check, if interface is VLAN interface
+if ! [ -e "/tmp/vlan.${netif}.phy" ]; then
+    for i in "/tmp/vlan.${netif}".*; do
+        [ -e "$i" ] || continue
+        export DO_VLAN=yes
+        break
+    done
+fi
+
+
+# bridge this interface?
+if [ -z "$NO_BRIDGE_MASTER" ]; then
+    for i in /tmp/bridge.*.info; do
+        [ -e "$i" ] || continue
+        unset bridgeslaves
+        unset bridgename
+        # shellcheck disable=SC1090
+        . "$i"
+        for ethname in $bridgeslaves; do
+            [ "$netif" != "$ethname" ] && continue
+
+            NO_BRIDGE_MASTER=yes NO_AUTO_DHCP=yes ifup "$ethname"
+            linkup "$ethname"
+            if [ ! -e "/tmp/bridge.$bridgename.up" ]; then
+                ip link add name "$bridgename" type bridge
+                echo 0 > "/sys/devices/virtual/net/$bridgename/bridge/forward_delay"
+                : > "/tmp/bridge.$bridgename.up"
+            fi
+            ip link set dev "$ethname" master "$bridgename"
+            ifup "$bridgename"
+            exit 0
+        done
+    done
+fi
+
+# enslave this interface to bond?
+if [ -z "$NO_BOND_MASTER" ]; then
+    for i in /tmp/bond.*.info; do
+        [ -e "$i" ] || continue
+        unset bondslaves
+        unset bondname
+        # shellcheck disable=SC1090
+        . "$i"
+        for testslave in $bondslaves; do
+            [ "$netif" != "$testslave" ] && continue
+
+            # already setup
+            [ -e "/tmp/bond.$bondname.up" ] && exit 0
+
+            # wait for all slaves to show up
+            for slave in $bondslaves; do
+                # try to create the slave (maybe vlan or bridge)
+                NO_BOND_MASTER=yes NO_AUTO_DHCP=yes ifup "$slave"
+
+                if ! ip link show dev "$slave" > /dev/null 2>&1; then
+                    # wait for the last slave to show up
+                    exit 0
+                fi
+            done
+
+            modprobe -q -b bonding
+            echo "+$bondname" > /sys/class/net/bonding_masters 2> /dev/null
+            ip link set "$bondname" down
+
+            # Stolen from ifup-eth
+            # add the bits to setup driver parameters here
+            for arg in $bondoptions; do
+                key=${arg%%=*}
+                value=${arg##*=}
+                # %{value:0:1} is replaced with non-bash specific construct
+                if [ "${key}" = "arp_ip_target" -a "${#value}" != "0" -a "+${value%%+*}" != "+" ]; then
+                    OLDIFS=$IFS
+                    IFS=','
+                    for arp_ip in $value; do
+                        echo "+$arp_ip" > "/sys/class/net/${bondname}/bonding/$key"
+                    done
+                    IFS=$OLDIFS
+                else
+                    echo "$value" > "/sys/class/net/${bondname}/bonding/$key"
+                fi
+            done
+
+            linkup "$bondname"
+
+            for slave in $bondslaves; do
+                cat "/sys/class/net/$slave/address" > "/tmp/net.${bondname}.${slave}.hwaddr"
+                ip link set "$slave" down
+                echo "+$slave" > "/sys/class/net/$bondname/bonding/slaves"
+                linkup "$slave"
+            done
+
+            # Set mtu on bond master
+            [ -n "$bondmtu" ] && ip link set mtu "$bondmtu" dev "$bondname"
+
+            # add the bits to setup the needed post enslavement parameters
+            for arg in $bondoptions; do
+                key=${arg%%=*}
+                value=${arg##*=}
+                if [ "${key}" = "primary" ]; then
+                    echo "$value" > "/sys/class/net/${bondname}/bonding/$key"
+                fi
+            done
+
+            : > "/tmp/bond.$bondname.up"
+
+            NO_BOND_MASTER=yes ifup "$bondname"
+            exit $?
+        done
+    done
+fi
+
+if [ -z "$NO_TEAM_MASTER" ]; then
+    for i in /tmp/team.*.info; do
+        [ -e "$i" ] || continue
+        unset teammaster
+        unset teamslaves
+        # shellcheck disable=SC1090
+        . "$i"
+        for testslave in $teamslaves; do
+            [ "$netif" != "$testslave" ] && continue
+
+            [ -e "/tmp/team.$teammaster.up" ] && exit 0
+
+            # wait for all slaves to show up
+            for slave in $teamslaves; do
+                # try to create the slave (maybe vlan or bridge)
+                NO_TEAM_MASTER=yes NO_AUTO_DHCP=yes ifup "$slave"
+
+                if ! ip link show dev "$slave" > /dev/null 2>&1; then
+                    # wait for the last slave to show up
+                    exit 0
+                fi
+            done
+
+            if [ ! -e "/tmp/team.$teammaster.up" ]; then
+                # We shall only bring up those _can_ come up
+                # in case of some slave is gone in active-backup mode
+                working_slaves=""
+                for slave in $teamslaves; do
+                    teamdctl "${teammaster}" port present "${slave}" 2> /dev/null \
+                        && continue
+                    ip link set dev "$slave" up 2> /dev/null
+                    if wait_for_if_up "$slave"; then
+                        working_slaves="$working_slaves$slave "
+                    fi
+                done
+                # Do not add slaves now
+                teamd -d -U -n -N -t "$teammaster" -f "/etc/teamd/${teammaster}.conf"
+                for slave in $working_slaves; do
+                    # team requires the slaves to be down before joining team
+                    ip link set dev "$slave" down
+                    (
+                        # TODO: does SUSE have something equivalent?
+                        unset TEAM_PORT_CONFIG
+                        #_hwaddr=$(cat "/sys/class/net/$slave/address")
+                        #_subchannels=$(iface_get_subchannels "$slave")
+                        #if [ -n "$_hwaddr" ] && [ -e "/etc/sysconfig/network-scripts/mac-${_hwaddr}.conf" ]; then
+                        #    # shellcheck disable=SC1090
+                        #    . "/etc/sysconfig/network-scripts/mac-${_hwaddr}.conf"
+                        #elif [ -n "$_subchannels" ] && [ -e "/etc/sysconfig/network-scripts/ccw-${_subchannels}.conf" ]; then
+                        #    # shellcheck disable=SC1090
+                        #    . "/etc/sysconfig/network-scripts/ccw-${_subchannels}.conf"
+                        #elif [ -e "/etc/sysconfig/network-scripts/ifcfg-${slave}" ]; then
+                        #    # shellcheck disable=SC1090
+                        #    . "/etc/sysconfig/network-scripts/ifcfg-${slave}"
+                        #fi
+
+                        if [ -n "${TEAM_PORT_CONFIG}" ]; then
+                            /usr/bin/teamdctl "${teammaster}" port config update "${slave}" "${TEAM_PORT_CONFIG}"
+                        fi
+                    )
+                    teamdctl "$teammaster" port add "$slave"
+                done
+
+                ip link set dev "$teammaster" up
+
+                : > "/tmp/team.$teammaster.up"
+                NO_TEAM_MASTER=yes ifup "$teammaster"
+                exit $?
+            fi
+        done
+    done
+fi
+
+# all synthetic interfaces done.. now check if the interface is available
+if ! ip link show dev "$netif" > /dev/null 2>&1; then
+    exit 1
+fi
+
+# disable manual ifup while netroot is set for simplifying our logic
+# in netroot case we prefer netroot to bringup $netif automatically
+[ -n "$2" -a "$2" = "-m" ] && [ -z "$netroot" ] && manualup="$2"
+
+if [ -n "$manualup" ]; then
+    : > "/tmp/net.$netif.manualup"
+    rm -f "/tmp/net.${netif}.did-setup"
+else
+    [ -e "/tmp/net.${netif}.did-setup" ] && exit 0
+    [ -z "$DO_VLAN" ] \
+        && [ -e "/sys/class/net/$netif/address" ] \
+        && [ -e "/tmp/net.$(cat "/sys/class/net/$netif/address").did-setup" ] && exit 0
+fi
+
+
+# Specific configuration, spin through the kernel command line
+# looking for ip= lines
+for p in $(getargs ip=); do
+    ip_to_var "$p"
+    # skip ibft
+    [ "$autoconf" = "ibft" ] && continue
+
+    case "$dev" in
+        ??:??:??:??:??:??) # MAC address
+            _dev=$(iface_for_mac "$dev")
+            [ -n "$_dev" ] && dev="$_dev"
+            ;;
+        ??-??-??-??-??-??) # MAC address in BOOTIF form
+            _dev=$(iface_for_mac "$(fix_bootif "$dev")")
+            [ -n "$_dev" ] && dev="$_dev"
+            ;;
+    esac
+
+    # If this option isn't directed at our interface, skip it
+    if [ -n "$dev" ]; then
+        [ "$dev" != "$netif" ] && continue
+    else
+        iface_is_enslaved "$netif" && continue
+    fi
+
+    # Store config for later use
+    for i in ip srv gw mask hostname macaddr mtu dns1 dns2; do
+        eval '[ "$'$i'" ] && echo '$i'="$'$i'"'
+    done > "/tmp/net.$netif.override"
+
+    for autoopt in $(str_replace "$autoconf" "," " "); do
+        case $autoopt in
+            dhcp | on | any)
+                do_dhcp -4
+                ;;
+            single-dhcp)
+                # wicked does not support this
+                exit 1
+                ;;
+            dhcp6)
+                load_ipv6
+                do_dhcp -6
+                ;;
+            auto6)
+                do_ipv6auto
+                ;;
+            either6)
+                do_ipv6auto || do_dhcp -6
+                ;;
+            link6)
+                do_ipv6link
+                ;;
+            *)
+                do_static
+                ;;
+        esac
+    done
+    ret=$?
+
+    # setup nameserver
+    for s in "$dns1" "$dns2" $(getargs nameserver); do
+        [ -n "$s" ] || continue
+        echo "nameserver $s" >> "/tmp/net.$netif.resolv.conf"
+    done
+
+    if [ $ret -eq 0 ]; then
+        : > "/tmp/net.${netif}.up"
+
+        if [ -z "$DO_VLAN" ] && [ -e "/sys/class/net/${netif}/address" ]; then
+            : > "/tmp/net.$(cat "/sys/class/net/${netif}/address").up"
+        fi
+
+        # and finally, finish interface set up if there isn't already a script
+        # to do so (which is the case in the dhcp path)
+        if [ ! -e "$hookdir/initqueue/setup_net_$netif.sh" ]; then
+            setup_net "$netif"
+            source_hook initqueue/online "$netif"
+            if [ -z "$manualup" ]; then
+                /sbin/netroot "$netif"
+            fi
+        fi
+
+        if command -v wicked > /dev/null && [ -z "$manualup" ]; then
+            /sbin/netroot "$netif"
+        fi
+
+        exit $ret
+    fi
+done
+
+# no ip option directed at our interface?
+if [ -z "$NO_AUTO_DHCP" ] && [ ! -e "/tmp/net.${netif}.up" ]; then
+    ret=1
+    if [ -e /tmp/net.bootdev ]; then
+        BOOTDEV=$(cat /tmp/net.bootdev)
+        if [ "$netif" = "$BOOTDEV" ] || [ "$BOOTDEV" = "$(cat "/sys/class/net/${netif}/address")" ]; then
+            do_dhcp
+            ret=$?
+        fi
+    else
+        # No ip lines, no bootdev -> default to dhcp
+        ip=$(getarg ip)
+
+        if getargs 'ip=dhcp6' > /dev/null || [ -z "$ip" -a "$netroot" = "dhcp6" ]; then
+            load_ipv6
+            do_dhcp -6
+            ret=$?
+        fi
+        if getargs 'ip=dhcp' > /dev/null || [ -z "$ip" -a "$netroot" != "dhcp6" ]; then
+            do_dhcp -4
+            ret=$?
+        fi
+    fi
+
+    for s in $(getargs nameserver); do
+        [ -n "$s" ] || continue
+        echo "nameserver $s" >> "/tmp/net.$netif.resolv.conf"
+    done
+
+    if [ "$ret" -eq 0 ] && [ -n "$(ls "/tmp/leaseinfo.${netif}"* 2> /dev/null)" ]; then
+        : > "/tmp/net.${netif}.did-setup"
+        if [ -e "/sys/class/net/${netif}/address" ]; then
+            : > "/tmp/net.$(cat "/sys/class/net/${netif}/address").did-setup"
+        fi
+    fi
+fi
+
+exit 0

--- a/modules.d/35network-wicked/wicked-net-genrules.sh
+++ b/modules.d/35network-wicked/wicked-net-genrules.sh
@@ -1,0 +1,135 @@
+#!/bin/sh
+# This file is part of dracut.
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# rework from 35network-legacy/net-genrules.sh
+
+type getargbool > /dev/null 2>&1 || . /lib/dracut-lib.sh
+
+if getargbool 0 rd.net.wickedonly; then
+    return
+fi
+
+getargbool 0 rd.neednet && NEEDNET=1
+
+# Don't continue if we don't need network
+if [ -z "$netroot" ] && [ ! -e "/tmp/net.ifaces" ] && [ "$NEEDNET" != "1" ]; then
+    return
+fi
+
+command -v fix_bootif > /dev/null || . /lib/net-lib.sh
+
+# Write udev rules
+{
+    # bridge: attempt only the defined interface
+    for i in /tmp/bridge.*.info; do
+        [ -e "$i" ] || continue
+        unset bridgeslaves
+        unset bridgename
+        # shellcheck disable=SC1090
+        . "$i"
+        RAW_IFACES="$RAW_IFACES $bridgeslaves"
+        MASTER_IFACES="$MASTER_IFACES $bridgename"
+    done
+
+    # bond: attempt only the defined interface (override bridge defines)
+    for i in /tmp/bond.*.info; do
+        [ -e "$i" ] || continue
+        unset bondslaves
+        unset bondname
+        # shellcheck disable=SC1090
+        . "$i"
+        # It is enough to fire up only one
+        RAW_IFACES="$RAW_IFACES $bondslaves"
+        MASTER_IFACES="$MASTER_IFACES ${bondname}"
+    done
+
+    for i in /tmp/team.*.info; do
+        [ -e "$i" ] || continue
+        unset teamslaves
+        unset teammaster
+        # shellcheck disable=SC1090
+        . "$i"
+        RAW_IFACES="$RAW_IFACES ${teamslaves}"
+        MASTER_IFACES="$MASTER_IFACES ${teammaster}"
+    done
+
+    for i in /tmp/vlan.*.phy; do
+        [ -e "$i" ] || continue
+        unset phydevice
+        # shellcheck disable=SC1090
+        . "$i"
+        RAW_IFACES="$RAW_IFACES $phydevice"
+        for j in /tmp/vlan.*".${phydevice}"; do
+            [ -e "$j" ] || continue
+            unset vlanname
+            # shellcheck disable=SC1090
+            . "$j"
+            MASTER_IFACES="$MASTER_IFACES ${vlanname}"
+        done
+    done
+
+    MASTER_IFACES="$(trim "$MASTER_IFACES")"
+    RAW_IFACES="$(trim "$RAW_IFACES")"
+
+    if [ -z "$IFACES" ]; then
+        [ -e /tmp/net.ifaces ] && read -r IFACES < /tmp/net.ifaces
+    fi
+
+    if [ -e /tmp/net.bootdev ]; then
+        bootdev=$(cat /tmp/net.bootdev)
+    fi
+
+    # shellcheck disable=SC2016
+    ifup='/sbin/ifup $name'
+
+    runcmd="RUN+=\"/sbin/initqueue --name ifup-\$name --unique --onetime $ifup\""
+
+    # We have some specific interfaces to handle
+    if [ -n "${RAW_IFACES}${IFACES}" ]; then
+        echo 'SUBSYSTEM!="net", GOTO="net_end"'
+        echo 'ACTION!="add|change|move", GOTO="net_end"'
+        for iface in $IFACES $RAW_IFACES; do
+            case "$iface" in
+                ??:??:??:??:??:??) # MAC address
+                    cond="ATTR{address}==\"$iface\""
+                    echo "$cond, $runcmd, GOTO=\"net_end\""
+                    ;;
+                ??-??-??-??-??-??) # MAC address in BOOTIF form
+                    cond="ATTR{address}==\"$(fix_bootif "$iface")\""
+                    echo "$cond, $runcmd, GOTO=\"net_end\""
+                    ;;
+                *) # an interface name
+                    cond="ENV{INTERFACE}==\"$iface\""
+                    echo "$cond, $runcmd, GOTO=\"net_end\""
+                    cond="NAME==\"$iface\""
+                    echo "$cond, $runcmd, GOTO=\"net_end\""
+                    ;;
+            esac
+            # The GOTO prevents us from trying to ifup the same device twice
+        done
+        echo 'LABEL="net_end"'
+
+        for iface in $IFACES; do
+            if [ "$bootdev" = "$iface" ] || [ "$NEEDNET" = "1" ]; then
+                if [ -n "$netroot" ] && [ -n "$DRACUT_SYSTEMD" ]; then
+                    echo "systemctl is-active initrd-root-device.target || [ -f /tmp/net.${iface}.did-setup ]"
+                else
+                    echo "[ -f /tmp/net.${iface}.did-setup ]"
+                fi > "$hookdir"/initqueue/finished/wait-"$iface".sh
+            fi
+        done
+    # Default: We don't know the interface to use, handle all
+    # Fixme: waiting for the interface as well.
+    else
+        cond='ACTION=="add", SUBSYSTEM=="net", ENV{DEVTYPE}!="wlan|wwan"'
+        # if you change the name of "91-default-net.rules", also change modules.d/80cms/cmssetup.sh
+        echo "$cond, $runcmd" > /etc/udev/rules.d/91-default-net.rules
+        if [ "$NEEDNET" = "1" ]; then
+            # shellcheck disable=SC2016
+            echo 'for i in /tmp/net.*.did-setup; do [ -f "$i" ]  && exit 0; done; exit 1' > "$hookdir"/initqueue/finished/wait-network.sh
+        fi
+    fi
+
+    # if you change the name of "90-net.rules", also change modules.d/80cms/cmssetup.sh
+} > /etc/udev/rules.d/90-net.rules

--- a/modules.d/35network-wicked/wicked-parse-bond.sh
+++ b/modules.d/35network-wicked/wicked-parse-bond.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+# This file is part of dracut.
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# rework from 35network-legacy/parse-bond.sh
+#
+# Format:
+#       bond=<bondname>[:<bondslaves>[:<options>[:<mtu>]]]
+#
+#       bondslaves is a comma-separated list of physical (ethernet) interfaces
+#       options is a comma-separated list on bonding options (modinfo bonding for details) in format compatible with initscripts
+#       if options include multi-valued arp_ip_target option, then its values should be separated by semicolon.
+#
+#       bond without parameters assumes bond=bond0:eth0,eth1:mode=balance-rr
+#
+#       if the mtu is specified, it will be set on the bond master
+#
+
+type getargs > /dev/null 2>&1 || . /lib/dracut-lib.sh
+
+if getargbool 0 rd.net.wickedonly; then
+    return
+fi
+
+# We translate list of slaves to space-separated here to make it easier to loop over them in ifup
+# Ditto for bonding options
+parsebond() {
+    local v=${1}:
+    set --
+    while [ -n "$v" ]; do
+        set -- "$@" "${v%%:*}"
+        v=${v#*:}
+    done
+
+    case $# in
+        0)
+            bondname=bond0
+            bondslaves="eth0 eth1"
+            ;;
+        1)
+            bondname=$1
+            bondslaves="eth0 eth1"
+            ;;
+        2)
+            bondname=$1
+            bondslaves=$(str_replace "$2" "," " ")
+            ;;
+        3)
+            bondname=$1
+            bondslaves=$(str_replace "$2" "," " ")
+            bondoptions=$(str_replace "$3" "," " ")
+            ;;
+        4)
+            bondname=$1
+            bondslaves=$(str_replace "$2" "," " ")
+            bondoptions=$(str_replace "$3" "," " ")
+            bondmtu=$4
+            ;;
+        *) die "bond= requires zero to four parameters" ;;
+    esac
+}
+
+# Parse bond for bondname, bondslaves, bondmode, bondoptions and bondmtu
+for bond in $(getargs bond=); do
+    unset bondname
+    unset bondslaves
+    unset bondoptions
+    unset bondmtu
+    if [ "$bond" != "bond" ]; then
+        parsebond "$bond"
+    fi
+    # Simple default bond
+    if [ -z "$bondname" ]; then
+        bondname=bond0
+        bondslaves="eth0 eth1"
+    fi
+    # Make it suitable for initscripts export
+    bondoptions=$(str_replace "$bondoptions" ";" ",")
+
+    {
+        echo "bondname=$bondname"
+        echo "bondslaves=\"$bondslaves\""
+        echo "bondoptions=\"$bondoptions\""
+        echo "bondmtu=\"$bondmtu\""
+    } > "/tmp/bond.${bondname}.info"
+done

--- a/modules.d/35network-wicked/wicked-parse-bridge.sh
+++ b/modules.d/35network-wicked/wicked-parse-bridge.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+# This file is part of dracut.
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# rework from 35network-legacy/parse-bridge.sh
+#
+# Format:
+#       bridge=<bridgename>:<bridgeslaves>
+#
+#       <bridgeslaves> is a comma-separated list of physical (ethernet) interfaces
+#       bridge without parameters assumes bridge=br0:eth0
+#
+
+type getargs > /dev/null 2>&1 || . /lib/dracut-lib.sh
+
+if getargbool 0 rd.net.wickedonly; then
+    return
+fi
+
+parsebridge() {
+    local v=${1}:
+    set --
+    while [ -n "$v" ]; do
+        set -- "$@" "${v%%:*}"
+        v=${v#*:}
+    done
+    case $# in
+        0)
+            bridgename=br0
+            bridgeslaves=$iface
+            ;;
+        1) die "bridge= requires two parameters" ;;
+        2)
+            bridgename=$1
+            bridgeslaves=$(str_replace "$2" "," " ")
+            ;;
+        *) die "bridge= requires two parameters" ;;
+    esac
+}
+
+# Parse bridge for bridgename and bridgeslaves
+for bridge in $(getargs bridge=); do
+    unset bridgename
+    unset bridgeslaves
+    iface=eth0
+    # Read bridge= parameters if they exist
+    if [ "$bridge" != "bridge" ]; then
+        parsebridge "$bridge"
+    fi
+    # Simple default bridge
+    if [ -z "$bridgename" ]; then
+        bridgename=br0
+        bridgeslaves=$iface
+    fi
+    {
+        echo "bridgename=$bridgename"
+        echo "bridgeslaves=\"$bridgeslaves\""
+    } > /tmp/bridge.${bridgename}.info
+done

--- a/modules.d/35network-wicked/wicked-parse-ibft.sh
+++ b/modules.d/35network-wicked/wicked-parse-ibft.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# This file is part of dracut.
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# rework from 35network-legacy/parse-ibft.sh
+
+type getargbool > /dev/null 2>&1 || . /lib/dracut-lib.sh
+type ibft_to_cmdline > /dev/null 2>&1 || . /lib/net-lib.sh
+
+if getargbool 0 rd.net.wickedonly; then
+    return
+fi
+
+if getargbool 0 rd.iscsi.ibft -d "ip=ibft"; then
+    modprobe -b -q iscsi_boot_sysfs 2> /dev/null
+    modprobe -b -q iscsi_ibft
+    ibft_to_cmdline
+fi

--- a/modules.d/35network-wicked/wicked-parse-ifname.sh
+++ b/modules.d/35network-wicked/wicked-parse-ifname.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# This file is part of dracut.
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# rework from 35network-legacy/parse-ifname.sh
+#
+# Format:
+#       ifname=<interface>:<mac>
+#
+# Note letters in the macaddress must be lowercase!
+#
+# Examples:
+# ifname=eth0:4a:3f:4c:04:f8:d7
+#
+# Note when using ifname= to get persistent interface names, you must specify
+# an ifname= argument for each interface used in an ip= or fcoe= argument
+
+type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
+
+if getargbool 0 rd.net.wickedonly; then
+    return
+fi
+
+# check if there are any ifname parameters
+if ! getarg ifname= > /dev/null; then
+    return
+fi
+
+command -v parse_ifname_opts > /dev/null || . /lib/net-lib.sh
+
+# Check ifname= lines
+for p in $(getargs ifname=); do
+    parse_ifname_opts "$p"
+done

--- a/modules.d/35network-wicked/wicked-parse-ip-opts.sh
+++ b/modules.d/35network-wicked/wicked-parse-ip-opts.sh
@@ -1,0 +1,151 @@
+#!/bin/sh
+# This file is part of dracut.
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# rework from 35network-legacy/parse-ip-opts.sh
+#
+# Format:
+#       ip=[dhcp|on|any|single-dhcp]
+#
+#       ip=<interface>:[dhcp|on|any][:[<mtu>][:<macaddr>]]
+#
+#       ip=<client-IP-number>:<server-IP-number>:<gateway-IP-number>:<netmask>:<client-hostname>:<interface>:{dhcp|on|any|none|off}[:[<mtu>][:<macaddr>]]
+#
+# When supplying more than only ip= line, <interface> is mandatory and
+# bootdev= must contain the name of the primary interface to use for
+# routing,dns,dhcp-options,etc.
+#
+
+type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
+
+if getargbool 0 rd.net.wickedonly; then
+    return
+fi
+
+if [ -n "$netroot" ] && [ -z "$(getarg ip=)" ] && [ -z "$(getarg BOOTIF=)" ]; then
+    # No ip= argument(s) for netroot provided, defaulting to DHCP
+    return
+fi
+
+# Count ip= lines to decide whether we need bootdev= or not
+if [ -z "$NEEDBOOTDEV" ]; then
+    count=0
+    for p in $(getargs ip=); do
+        case "$p" in
+            ibft)
+                continue
+                ;;
+        esac
+        count=$((count + 1))
+    done
+    [ $count -gt 1 ] && NEEDBOOTDEV=1
+fi
+unset count
+
+# If needed, check if bootdev= contains anything usable
+BOOTDEV=$(getarg bootdev=)
+
+if [ -n "$NEEDBOOTDEV" ] && getargbool 1 rd.neednet; then
+    #[ -z "$BOOTDEV" ] && warn "Please supply bootdev argument for multiple ip= lines"
+    echo "rd.neednet=1" > /etc/cmdline.d/dracut-neednet.conf
+    info "Multiple ip= arguments: assuming rd.neednet=1"
+else
+    unset NEEDBOOTDEV
+fi
+
+# Check ip= lines
+# XXX Would be nice if we could errorcheck ip addresses here as well
+for p in $(getargs ip=); do
+    ip_to_var "$p"
+
+    # make first device specified the BOOTDEV
+    if [ -n "$NEEDBOOTDEV" ] && [ -z "$BOOTDEV" ] && [ -n "$dev" ]; then
+        BOOTDEV="$dev"
+        info "Setting bootdev to '$BOOTDEV'"
+    fi
+
+    # skip ibft since we did it above
+    [ "$autoconf" = "ibft" ] && continue
+
+    # Empty autoconf defaults to 'dhcp'
+    if [ -z "$autoconf" ]; then
+        warn "Empty autoconf values default to dhcp"
+        autoconf="dhcp"
+    fi
+
+    # Error checking for autoconf in combination with other values
+    for autoopt in $(str_replace "$autoconf" "," " "); do
+        case $autoopt in
+            error) die "Error parsing option 'ip=$p'" ;;
+            bootp | rarp | both) die "Sorry, ip=$autoopt is currenty unsupported" ;;
+            none | off)
+                [ -z "$ip" ] \
+                    && die "For argument 'ip=$p'\nValue '$autoopt' without static configuration does not make sense"
+                [ -z "$mask" ] \
+                    && die "Sorry, automatic calculation of netmask is not yet supported"
+                ;;
+            auto6 | link6) ;;
+            either6) ;;
+            dhcp | dhcp6 | on | any | single-dhcp)
+                [ -n "$NEEDBOOTDEV" ] && [ -z "$dev" ] \
+                    && die "Sorry, 'ip=$p' does not make sense for multiple interface configurations"
+                [ -n "$ip" ] \
+                    && die "For argument 'ip=$p'\nSorry, setting client-ip does not make sense for '$autoopt'"
+                ;;
+            *) die "For argument 'ip=$p'\nSorry, unknown value '$autoopt'" ;;
+        esac
+    done
+
+    if [ -n "$dev" ]; then
+        # We don't like duplicate device configs
+        if [ -n "$IFACES" ]; then
+            for i in $IFACES; do
+                [ "$dev" = "$i" ] && die "For argument 'ip=$p'\nDuplication configurations for '$dev'"
+            done
+        fi
+        # IFACES list for later use
+        IFACES="$IFACES $dev"
+    fi
+
+    # Do we need to check for specific options?
+    if [ -n "$NEEDDHCP" ] || [ -n "$DHCPORSERVER" ]; then
+        # Correct device? (Empty is ok as well)
+        [ "$dev" = "$BOOTDEV" ] || continue
+        # Server-ip is there?
+        [ -n "$DHCPORSERVER" ] && [ -n "$srv" ] && continue
+        # dhcp? (It's simpler to check for a set ip. Checks above ensure that if
+        # ip is there, we're static
+        [ -z "$ip" ] && continue
+        # Not good!
+        die "Server-ip or dhcp for netboot needed, but current arguments say otherwise"
+    fi
+
+    if str_starts "$dev" "enx" && [ ${#dev} -eq 15 ]; then
+        # shellcheck disable=SC2003
+        printf -- "ifname=%s:%s:%s:%s:%s:%s:%s\n" \
+            "$dev" \
+            "$(expr substr "$dev" 3 2)" \
+            "$(expr substr "$dev" 5 2)" \
+            "$(expr substr "$dev" 7 2)" \
+            "$(expr substr "$dev" 9 2)" \
+            "$(expr substr "$dev" 11 2)" \
+            "$(expr substr "$dev" 13 2)" \
+            >> /etc/cmdline.d/80-enx.conf
+    fi
+done
+
+# put BOOTIF in IFACES to make sure it comes up
+if getargbool 1 "rd.bootif" && BOOTIF="$(getarg BOOTIF=)"; then
+    BOOTDEV=$(fix_bootif "$BOOTIF")
+    IFACES="$BOOTDEV $IFACES"
+fi
+
+# This ensures that BOOTDEV is always first in IFACES
+if [ -n "$BOOTDEV" ] && [ -n "$IFACES" ]; then
+    IFACES="${IFACES%$BOOTDEV*} ${IFACES#*$BOOTDEV}"
+    IFACES="$BOOTDEV $IFACES"
+fi
+
+# Store BOOTDEV and IFACES for later use
+[ -n "$BOOTDEV" ] && echo "$BOOTDEV" > /tmp/net.bootdev
+[ -n "$IFACES" ] && echo "$IFACES" > /tmp/net.ifaces

--- a/modules.d/35network-wicked/wicked-parse-team.sh
+++ b/modules.d/35network-wicked/wicked-parse-team.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+# This file is part of dracut.
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# rework from 35network-legacy/parse-team.sh
+#
+# Format:
+#       team=<teammaster>:<teamslaves>[:<teamrunner>]
+#
+#       teamslaves is a comma-separated list of physical (ethernet) interfaces
+#       teamrunner is the runner type to be used (see teamd.conf(5)); defaults to activebackup
+#
+#       team without parameters assumes team=team0:eth0,eth1:activebackup
+#
+
+type getargs > /dev/null 2>&1 || . /lib/dracut-lib.sh
+
+if getargbool 0 rd.net.wickedonly; then
+    return
+fi
+
+parseteam() {
+    local v=${1}:
+    set --
+    while [ -n "$v" ]; do
+        set -- "$@" "${v%%:*}"
+        v=${v#*:}
+    done
+
+    case $# in
+        0)
+            teammaster=team0
+            teamslaves="eth0 eth1"
+            teamrunner="activebackup"
+            ;;
+        1)
+            teammaster=$1
+            teamslaves="eth0 eth1"
+            teamrunner="activebackup"
+            ;;
+        2)
+            teammaster=$1
+            teamslaves=$(str_replace "$2" "," " ")
+            teamrunner="activebackup"
+            ;;
+        3)
+            teammaster=$1
+            teamslaves=$(str_replace "$2" "," " ")
+            teamrunner=$3
+            ;;
+        *) die "team= requires zero to three parameters" ;;
+    esac
+    return 0
+}
+
+for team in $(getargs team); do
+    [ "$team" = "team" ] && continue
+
+    unset teammaster
+    unset teamslaves
+    unset teamrunner
+
+    parseteam "$team" || continue
+
+    {
+        echo "teammaster=$teammaster"
+        echo "teamslaves=\"$teamslaves\""
+        echo "teamrunner=\"$teamrunner\""
+    } > /tmp/team."${teammaster}".info
+
+    if ! [ -e /etc/teamd/"${teammaster}".conf ]; then
+        warn "Team master $teammaster specified, but no /etc/teamd/$teammaster.conf present. Using $teamrunner."
+        mkdir -p /etc/teamd
+        printf -- "%s" "{\"runner\": {\"name\": \"$teamrunner\"}, \"link_watch\": {\"name\": \"ethtool\"}}" > "/tmp/${teammaster}.conf"
+    fi
+done

--- a/modules.d/35network-wicked/wicked-parse-vlan.sh
+++ b/modules.d/35network-wicked/wicked-parse-vlan.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# This file is part of dracut.
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# rework from 35network-legacy/parse-vlan.sh
+#
+# Format:
+#	vlan=<vlanname>:<phydevice>
+#
+
+type getargs > /dev/null 2>&1 || . /lib/dracut-lib.sh
+
+if getargbool 0 rd.net.wickedonly; then
+    return
+fi
+
+parsevlan() {
+    local v=${1}:
+    set --
+    while [ -n "$v" ]; do
+        set -- "$@" "${v%%:*}"
+        v=${v#*:}
+    done
+
+    unset vlanname phydevice
+    case $# in
+        2)
+            vlanname=$1
+            phydevice=$2
+            ;;
+        *) die "vlan= requires two parameters" ;;
+    esac
+}
+
+for vlan in $(getargs vlan=); do
+    unset vlanname
+    unset phydevice
+    if [ ! "$vlan" = "vlan" ]; then
+        parsevlan "$vlan"
+    fi
+
+    echo "phydevice=\"$phydevice\"" > /tmp/vlan."${phydevice}".phy
+    {
+        echo "vlanname=\"$vlanname\""
+        echo "phydevice=\"$phydevice\""
+    } > /tmp/vlan."${vlanname}"."${phydevice}"
+done

--- a/modules.d/35network-wicked/wicked-run.sh
+++ b/modules.d/35network-wicked/wicked-run.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+type getargbool > /dev/null 2>&1 || . /lib/dracut-lib.sh
+
+if ! getargbool 0 rd.net.wickedonly; then
+    return
+fi
+
 # ensure wickedd is running
 systemctl start wickedd
 # detection wrapper around ifup --ifconfig "final xml" all

--- a/modules.d/40network/module-setup.sh
+++ b/modules.d/40network/module-setup.sh
@@ -17,7 +17,7 @@ depends() {
     done
 
     if [ -z "$network_handler" ]; then
-        if [[ -x $dracutsysrootdir$systemdsystemunitdir/wicked.service ]]; then
+        if [[ -e $dracutsysrootdir$systemdsystemunitdir/wicked.service ]]; then
             network_handler="network-wicked"
         elif [[ -x $dracutsysrootdir/usr/libexec/nm-initrd-generator ]]; then
             network_handler="network-manager"

--- a/modules.d/40network/net-lib.sh
+++ b/modules.d/40network/net-lib.sh
@@ -188,8 +188,10 @@ setup_net() {
     if [ "$layer2" != "0" ] && [ -n "$dest" ] && ! strstr "$dest" ":"; then
         if command -v arping2 > /dev/null; then
             arping2 -q -C 1 -c 60 -I "$netif" "$dest" || info "Resolving $dest via ARP on $netif failed"
-        else
+        elif command -v arping > /dev/null; then
             arping -q -f -w 60 -I "$netif" "$dest" || info "Resolving $dest via ARP on $netif failed"
+        elif command -v wicked > /dev/null; then
+            wicked arp ping --quiet --interval 1000 --timeout 60000 "$netif" "$dest" || info "Resolving $dest via ARP on $netif failed"
         fi
     fi
     unset layer2


### PR DESCRIPTION
***This PR in not intended to be merged.***

### Motivation

Following up on [boo#1182227](https://bugzilla.opensuse.org/show_bug.cgi?id=1182227), it seems like a good idea to have a workshop to serve as validation of the network-wicked module, if we plan to use it exclusively and drop the network-legacy support.

### `rd.net.wickedonly` command line parameter for testing

To speed up testing, control how this module is going to work using the `rd.net.wickedonly` command line parameter:
- If not present, use legacy ifup and net-genrules.
- If present, use just wicked.

So, it's easy to test the same network configuration just editing the GRUB command line before booting.

### Network command line parameters handled by the network-legacy module

Extracted from [dracut man page](https://mirrors.edge.kernel.org/pub/linux/utils/boot/dracut/dracut.html#_network). As they are tested and working, their status will change to checked. This list will be refined with specific tests of each option.

- [ ] `ip={dhcp|on|any|single-dhcp|dhcp6|auto6|either6|link6}`
    - [ ] `dhcp|on|any` - Get ip from dhcp server from all interfaces.
        - [ ] If `netroot=dhcp`, loop sequentially through all interfaces (eth0, eth1, ...) and use the first with a valid DHCP root-path.
    - [ ] `single-dhcp` - Send DHCP on all available interfaces in parallel, as opposed to one after another. After the first DHCP response is received, stop DHCP on all other interfaces.
    - [ ] `auto6` - IPv6 autoconfiguration
    - [ ] `dhcp6` - IPv6 DHCP
    - [ ] `either6` - If auto6 fails, then dhcp6.
    - [ ] `link6` - Bring up IPv6 link-local addressing.
- [ ] `ip=<interface>:{dhcp|on|any|dhcp6|auto6|link6}[:[<mtu>][:<macaddr>]]`
    - [ ] `dhcp|on|any`- Get ip from dhcp server on a specific interface.
    - [ ] `dhcp6` - IPv6 DHCP on a specific interface.
    - [ ] `auto6` - IPv6 autoconfiguration on a specific interface.
    - [ ] `link6` - Bring up interface for IPv6 link local address.
    - [ ] `<macaddr>` - Optionally set `<macaddr>` on the `<interface>`. This cannot be used in conjunction with the `ifname` argument for the same `<interface>`.
- [ ] `ip=<client-IP>:[<peer>]:<gateway-IP>:<netmask>:<client_hostname>:<interface>:{none|off|dhcp|on|any|dhcp6|auto6|ibft}[:[<mtu>][:<macaddr>]]` - Explicit network configuration. If you want do define a IPv6 address, put it in brackets (e.g. [2001:DB8::1]). `<peer>` is optional and is the address of the remote endpoint for PPP interfaces and it may be followed by a slash and a decimal number, encoding the network prefix length.
- [ ] `ip=<client-IP>:[<peer>]:<gateway-IP>:<netmask>:<client_hostname>:<interface>:{none|off|dhcp|on|any|dhcp6|auto6|ibft}[:[<dns1>][:<dns2>]]` - Explicit network configuration (same description as previous item).
- [x] `ifname=<interface>:<MAC>` - Assign network device name `<interface>` to the NIC with MAC.
- [ ] `rd.route=<net>/<netmask>:<gateway>[:<interface>]` - Add a static route with route options, which are separated by a colon. IPv6 addresses have to be put in brackets.
- [ ] `bootdev=<interface>` - Specify network interface to use routing and netroot information from. Required if multiple ip= lines are used.
- [ ] `BOOTIF=<MAC>` - Specify network interface to use routing and netroot information from.
- [ ] `rd.bootif=0` - Disable `BOOTIF` parsing, which is provided by PXE.
- [ ] `nameserver=<IP> [nameserver=<IP> …]` - Specify nameserver(s) to use.
- [ ] `rd.peerdns=0` - Disable DNS setting of DHCP parameters.
- [ ] ~~`biosdevname=0`~~ - Turn off biosdevname network interface renaming (it seems old stuff linked to the 97biosdevname module).
- [ ] `rd.neednet=1` - Bring up network even without `netroot` set.
- [ ] `vlan=<vlanname>:<phydevice>` - Setup vlan device named `<vlanname>` on `<phydevice>`. We support the four styles of vlan names: VLAN_PLUS_VID (vlan0005), VLAN_PLUS_VID_NO_PAD (vlan5), DEV_PLUS_VID (eth0.0005), DEV_PLUS_VID_NO_PAD (eth0.5).
- [ ] `bond=<bondname>[:<bondslaves>:[:<options>[:<mtu>]]]` - Setup bonding device `<bondname>` on top of `<bondslaves>`. `<bondslaves>` is a comma-separated list of physical (ethernet) interfaces. `<options>` is a comma-separated list on bonding options (modinfo bonding for details) in format compatible with initscripts. If `<options>` includes multi-valued arp_ip_target option, then its values should be separated by semicolon. if the mtu is specified, it will be set on the bond master. Bond without parameters assumes `bond=bond0:eth0,eth1:mode=balance-rr`
- [ ] `team=<teammaster>:<teamslaves>[:<teamrunner>]` - Setup team device `<teammaster>` on top of `<teamslaves>`. `<teamslaves>` is a comma-separated list of physical (ethernet) interfaces. `<teamrunner>` is the runner type to be used (see teamd.conf(5)); defaults to `activebackup`. Team without parameters assumes `team=team0:eth0,eth1:activebackup`
- [ ] `bridge=<bridgename>:<ethnames>` - Setup bridge `<bridgename>` with `<ethnames>`. `<ethnames>` is a comma-separated list of physical (ethernet) interfaces. Bridge without parameters assumes `bridge=br0:eth0`
- [ ] `rd.iscsi.ibft=1` - Turn on iBFT autoconfiguration for the interfaces.