### PR TITLE
fix(dracut-functions): skip iSCSI sessions without initiatorname (bsc#1195011)

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -888,13 +888,17 @@ block_is_nbd() {
 # Check whether $1 is an nbd device
 block_is_iscsi() {
     local _dir
-    local _dev=$1
+    local _dev=$1 _real _sess
     [[ -L "/sys/dev/block/$_dev" ]] || return
     _dir="$(readlink -f "/sys/dev/block/$_dev")" || return
     until [[ -d "$_dir/sys" || -d "$_dir/iscsi_session" ]]; do
         _dir="$_dir/.."
     done
-    [[ -d "$_dir/iscsi_session" ]]
+    [[ -d "$_dir/iscsi_session" ]] && {
+        _real=$(realpath "$_dir")
+        _sess=${_real##*/}
+        [[ -f "$_real/iscsi_session/$_sess/initiatorname" ]]
+    }
 }
 
 # block_is_fcoe <maj:min>


### PR DESCRIPTION
The qla4xxx iSCSI transport doesn't need to be set up using iscsiadm
commands, as it's configured in the flashnode. Such connections
don't have an "initiatorname" attribute in their iscsi_session
sysfs directory. Don't configure iSCSI for this type of session.

Signed-off-by: Martin Wilck <mwilck@suse.com>
