### PR TITLE
fix(kernel-modules-extra): handle zstd module extension

### DIFF
--- a/modules.d/90kernel-modules-extra/module-setup.sh
+++ b/modules.d/90kernel-modules-extra/module-setup.sh
@@ -173,7 +173,7 @@ installkernel() {
 
     ((${#pathlist[@]} > 0)) || return 0
 
-    printf "^%s\.ko(\.gz|\.bz2|\.xz)?:\n" "${pathlist[@]}" \
+    printf "^%s\.ko(\.gz|\.bz2|\.xz|\.zst)?:\n" "${pathlist[@]}" \
         | (LANG=C grep -E -o -f - -- "$depmod_modules_dep" || exit 0) \
         | tr -d ':' \
         | (


### PR DESCRIPTION
The regular expression here is trying to handle various kernel
module compression schemas and was missing the zst extension
which indicates use of zstd.

Signed-off-by: Dirk Mueller <dmueller@suse.com>

Upstream https://github.com/dracutdevs/dracut/pull/1675