### PR TITLE
fix(tpm2-tss): install SUSE specific files (bsc#1195984)

### DIFF
--- a/modules.d/91tpm2-tss/module-setup.sh
+++ b/modules.d/91tpm2-tss/module-setup.sh
@@ -32,9 +32,9 @@ installkernel() {
 install() {
 
     inst_multiple -o \
-        "$sysusers"/tpm2-tss.conf \
-        "$tmpfilesdir"/tpm2-tss-fapi.conf \
-        "$udevrulesdir"/60-tpm-udev.rules \
+        "$sysusers"/system-user-tss.conf \
+        "$tmpfilesdir"/tpm2-tss-fapi*.conf \
+        "$udevrulesdir"/90-tpm.rules \
         tpm2_pcrread tpm2_pcrextend tpm2_createprimary tpm2_createpolicy \
         tpm2_create tpm2_load tpm2_unseal tpm2
 


### PR DESCRIPTION
There are three files that differ from upstream:
- `/usr/lib/sysusers.d/tpm2-tss.conf`       -> `system-user-tss.conf`
- `/usr/lib/tmpfiles.d/tpm2-tss-fapi.conf`  -> `tpm2-tss-fapi-3.1.0.conf`
- `/usr/lib/udev/rules.d/60-tpm-udev.rules` -> `90-tpm.rules`