### PR TITLE
fix(systemd-sysusers): override systemd-sysusers.service (bsc#1195983)

### DIFF
--- a/modules.d/01systemd-sysusers/module-setup.sh
+++ b/modules.d/01systemd-sysusers/module-setup.sh
@@ -24,6 +24,8 @@ depends() {
 # Install the required file(s) and directories for the module in the initramfs.
 install() {
 
+    inst_simple "$moddir/sysusers-dracut.conf" "$systemdsystemunitdir/systemd-sysusers.service.d/sysusers-dracut.conf"
+
     inst_multiple -o \
         "$sysusers"/basic.conf \
         "$sysusers"/systemd.conf \

--- a/modules.d/01systemd-sysusers/sysusers-dracut.conf
+++ b/modules.d/01systemd-sysusers/sysusers-dracut.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionNeedsUpdate=


### PR DESCRIPTION
Fixes a regression with `systemd` not running units with `ConditionNeedsUpdate` set in initrds.

(cherry picked from commit dcbe23c14d13ca335ad327b7bb985071ca442f12)

Fixes https://github.com/dracutdevs/dracut/issues/1700 in SUSE, follows https://github.com/dracutdevs/dracut/pull/1701

Needs to be merged **before** https://github.com/openSUSE/dracut/pull/137