### PR TITLE
fix(bluetooth): make hostonly configuration files optional (bsc#1195047)

### DIFF
--- a/modules.d/62bluetooth/module-setup.sh
+++ b/modules.d/62bluetooth/module-setup.sh
@@ -67,7 +67,7 @@ install() {
     if [[ $hostonly ]]; then
         var_lib_files=("$dracutsysrootdir"/var/lib/bluetooth/**)
 
-        inst_multiple \
+        inst_multiple -o \
             /etc/bluetooth/main.conf \
             /etc/dbus-1/system.d/bluetooth.conf \
             "${var_lib_files[@]#"$dracutsysrootdir"}"


### PR DESCRIPTION
Do not fail if any of the expected configuration files don't exist.

(cherry picked from commit d03fb675d8e904c6c44de9b91814b33c45043f4f)
