### PR TITLE
revert(lvm): remove 69-dm-lvm-metad.rules

### DIFF
--- a/modules.d/90lvm/module-setup.sh
+++ b/modules.d/90lvm/module-setup.sh
@@ -92,20 +92,7 @@ install() {
         } > "${initdir}/etc/lvm/lvm.conf"
     fi
 
-    inst_rules 11-dm-lvm.rules 69-dm-lvm-metad.rules
-
-    # Do not run lvmetad update via pvscan in udev rule  - lvmetad is not running yet in dracut!
-    if [[ -f ${initdir}/lib/udev/rules.d/69-dm-lvm-metad.rules ]]; then
-        if grep -q SYSTEMD_WANTS "${initdir}"/lib/udev/rules.d/69-dm-lvm-metad.rules; then
-            sed -i -e 's/^ENV{SYSTEMD_ALIAS}=.*/# No LVM pvscan in dracut - lvmetad is not running yet/' \
-                "${initdir}"/lib/udev/rules.d/69-dm-lvm-metad.rules
-            sed -i -e 's/^ENV{ID_MODEL}=.*//' "${initdir}"/lib/udev/rules.d/69-dm-lvm-metad.rules
-            sed -i -e 's/^ENV{SYSTEMD_WANTS}+\?=.*//' "${initdir}"/lib/udev/rules.d/69-dm-lvm-metad.rules
-        else
-            sed -i -e 's/.*lvm pvscan.*/# No LVM pvscan for in dracut - lvmetad is not running yet/' \
-                "${initdir}"/lib/udev/rules.d/69-dm-lvm-metad.rules
-        fi
-    fi
+    inst_rules 11-dm-lvm.rules
 
     # Gentoo ebuild for LVM2 prior to 2.02.63-r1 doesn't install above rules
     # files, but provides the one below:


### PR DESCRIPTION
## Changes

This udev rule runs pvscan to autoactivate VGs, which dracut
does not want to do, and previously disabled by editing the
rule file and commenting out lines.

This also stops /dev/disk/by-id/lvm-pv-uuid-* symlinks from
being created in the initrd.

Cherry-picked from upstream 50e74668434d935db649b5690dc2158b0f87d91c

## Checklist
- [ x] I have tested it locally

Fixes  [bsc#1195604](https://bugzilla.suse.com/show_bug.cgi?id=1195604)
