### PR TITLE
fix(dracut-systemd): do not use Requires for vconsole-setup.service (bsc#1195508)

### DIFF
--- a/modules.d/98dracut-systemd/dracut-cmdline-ask.service
+++ b/modules.d/98dracut-systemd/dracut-cmdline-ask.service
@@ -6,10 +6,11 @@
 Description=dracut ask for additional cmdline parameters
 DefaultDependencies=no
 Before=dracut-cmdline.service
-After=systemd-journald.socket
-After=systemd-vconsole-setup.service
-Requires=systemd-vconsole-setup.service
 Wants=systemd-journald.socket
+After=systemd-journald.socket
+Wants=systemd-vconsole-setup.service
+After=systemd-vconsole-setup.service
+
 ConditionPathExists=/usr/lib/initrd-release
 ConditionKernelCommandLine=|rd.cmdline=ask
 ConditionPathExistsGlob=|/etc/cmdline.d/*.conf


### PR DESCRIPTION
systemd-vconsole-setup.service may fail if the user specifies a missing keymap,
see [1,2,3], or font. This is unfortunate, but the system should not refuse
boot. It is better to continue, possible without the desired font or keymap.
All other systemd services that depend on systemd-vconsole-setup.service do so
without a hard Requires=.

(In particular, systemd-vconsole-setup internally will try to do as much setup
as possible, and will load the font even if it cannot load the keymap and vice
versa.)

[1] https://fedoraproject.org/wiki/Common_F34_bugs#kbd-legacy-media
[2] https://bugzilla.redhat.com/show_bug.cgi?id=1955162
[3] https://bugzilla.redhat.com/show_bug.cgi?id=1955793

(cherry picked from commit a7f5429cb81f7ffdf9bd5684af8d36725170b756)