### PR TITLE
fix(dasd_rules): correct udev dasd rules parsing (bsc#1195309)

### DIFF
--- a/modules.d/95dasd_rules/module-setup.sh
+++ b/modules.d/95dasd_rules/module-setup.sh
@@ -57,8 +57,8 @@ install() {
         [[ $_dasd ]] && printf "%s\n" "$_dasd" >> "${initdir}/etc/cmdline.d/95dasd.conf"
     fi
     if [[ $hostonly ]]; then
-        inst_rules_wildcard 51-dasd-*.rules
-        inst_rules_wildcard 41-dasd-*.rules
+        inst_rules_wildcard "51-dasd-*.rules"
+        inst_rules_wildcard "41-dasd-*.rules"
         mark_hostonly /etc/udev/rules.d/51-dasd-*.rules
         mark_hostonly /etc/udev/rules.d/41-dasd-*.rules
     fi


### PR DESCRIPTION
Arguments to the inst_rules_wildcard function need quoting

(cherry picked from commit 5de6e4d56e5206cb47f645ad1cb6d39794048c68)
