### PR TITLE
fix(resume): only exclude this module when swap is netdev (bsc#1194915) (SLE15-SP4:GA)

### DIFF
--- a/modules.d/95resume/module-setup.sh
+++ b/modules.d/95resume/module-setup.sh
@@ -10,10 +10,9 @@ check() {
         return 1
     }
 
-    # Only support resume if hibernation is currently on
-    # and no swap is mounted on a net device
+    # Only support resume if no swap is mounted on a net device
     [[ $hostonly ]] || [[ $mount_needs ]] && {
-        swap_on_netdevice || [[ "$(cat /sys/power/resume)" == "0:0" ]] && return 255
+        swap_on_netdevice && return 255
     }
 
     return 0


### PR DESCRIPTION
Always add the resume module in hostonly mode if no swap is mounted on a net device. Otherwise, it must be added manually.

Original-patch-by: Lukas Nykryn <lnykryn@redhat.com>