### PR TITLE
Repair POSIX compliance

### DIFF
--- a/modules.d/35network-legacy/ifup.sh
+++ b/modules.d/35network-legacy/ifup.sh
@@ -54,7 +54,9 @@ dhcp_wicked_apply() {
     if [ -n "${ROUTES}" ]; then
         for r in ${ROUTES}; do
             route=(${r//,/ })
-            [[ ${route[2]} == "0.0.0.0" ]] || gateway=" via ${route[2]}"
+            if [ ! ${route[2]} == "0.0.0.0" ]; then
+                gateway=" via ${route[2]}"
+            fi
             ip $1 route add "${route[0]}"/"${route[1]}""$gateway" dev "$INTERFACE"
         done
     fi

--- a/modules.d/45ifcfg/write-ifcfg-suse.sh
+++ b/modules.d/45ifcfg/write-ifcfg-suse.sh
@@ -156,13 +156,13 @@ for netup in /tmp/net.*.did-setup; do
             echo "BRIDGE='yes'"
             echo "BRIDGE_STP='off'"
             echo "BRIDGE_FORWARDDELAY='0'"
-            echo -n "BRIDGE_PORTS='"
+            printf "BRIDGE_PORTS='"
         } >> /tmp/ifcfg/ifcfg-"$netif"
 
         if [ "$ethname" = "$bondname" ]; then
             {
                 for slave in $bondslaves; do
-                    echo -n "$bondname "
+                    printf "$bondname "
                 done
                 echo "'"
             } >> /tmp/ifcfg/ifcfg-"$netif"


### PR DESCRIPTION
Signed-off-by: Georg Pfuetzenreuter <mail@georg-pfuetzenreuter.net>

Hi,

upon trying to build the openSUSE fork of dracut using `make check clean`, two errors occurred:

```
modules.d/35network-legacy/ifup.sh contains [[
modules.d/45ifcfg/write-ifcfg-suse.sh contains echo -n
```

This patch restores compatibility with the upstream POSIX compliance check.

Do I need to take care of any SUSE related version bumping / changelogging for patches here?

Best,
Georg