### PR TITLE
`network-legacy`: Support for static Wicked configuration

### DIFF
--- a/man/dracut.cmdline.7.asc
+++ b/man/dracut.cmdline.7.asc
@@ -580,7 +580,7 @@ module. Other network modules might support a slightly different set of
 options; refer to the documentation of the specific network module in use. For
 NetworkManager, see *nm-initrd-generator*(8).
 
-**ip=**__{dhcp|on|any|dhcp6|auto6|either6|link6|single-dhcp}__::
+**ip=**__{dhcp|on|any|dhcp6|auto6|either6|link6|single-dhcp|wicked-static}__::
     dhcp|on|any::: get ip from dhcp server from all interfaces. If netroot=dhcp,
     loop sequentially through all interfaces (eth0, eth1, ...) and use the first
     with a valid DHCP root-path.
@@ -598,6 +598,11 @@ NetworkManager, see *nm-initrd-generator*(8).
     either6::: if auto6 fails, then dhcp6
 
     link6::: bring up interface for IPv6 link-local addressing
+
+    wicked-static::: Apply static network configuration from the installed system.
+    Files from /etc/sysconfig/network/ are copied upon buildtime. Changes require
+    the initramfs to be rebuilt.
+    This is a SUSE specific feature.
 
 **ip=**__<interface>__:__{dhcp|on|any|dhcp6|auto6|link6}__[:[__<mtu>__][:__<macaddr>__]]::
     This parameter can be specified multiple times.

--- a/modules.d/35network-legacy/ifup.sh
+++ b/modules.d/35network-legacy/ifup.sh
@@ -304,12 +304,16 @@ do_wicked_static() {
         if [ "$BOOTPROTO" = "static" ] ; then
             autoconf=${BOOTPROTO}
             if [ -n "$IPADDR" ] ; then
+                # respect netmask priority described in ifcfg(5)
                 local cidr=${IPADDR#*/}
                 if [ "$cidr" != "$IPADDR" ] ; then
                     mask=${cidr}
                     ip=${IPADDR%/*}
                 elif [ -n "$PREFIXLEN" ] ; then
                     mask=${PREFIXLEN}
+                    ip=${IPADDR}
+                elif [ -n "$NETMASK" ] ; then
+                    mask=${NETMASK}
                     ip=${IPADDR}
                 fi
                 [ -n "$GATEWAY" ] && gw=${GATEWAY}

--- a/modules.d/35network-legacy/ifup.sh
+++ b/modules.d/35network-legacy/ifup.sh
@@ -297,6 +297,9 @@ do_ipv6link() {
 
 # Prepare static IP configuration based on wicked ifcfg
 do_wicked_static() {
+    unset BOOTPROTO IPADDR PREFIXLEN NETMASK GATEWAY NETCONFIG_DNS_STATIC_SERVERS NETCONFIG_DNS_STATIC_SEARCHLIST \
+          autoconf ip mask
+
     if [ -e /etc/sysconfig/network/ifcfg-${netif} ] ; then
         # Pull in existing interface configuration
         . /etc/sysconfig/network/ifcfg-${netif}

--- a/modules.d/35network-legacy/module-setup.sh
+++ b/modules.d/35network-legacy/module-setup.sh
@@ -58,6 +58,7 @@ install() {
 
     # SUSE specific files
     for f in \
+        /etc/sysconfig/network/config \
         /etc/sysconfig/network/ifcfg-* \
         /etc/sysconfig/network/ifroute-* \
         /etc/sysconfig/network/routes \

--- a/modules.d/35network-legacy/parse-ip-opts.sh
+++ b/modules.d/35network-legacy/parse-ip-opts.sh
@@ -84,6 +84,7 @@ for p in $(getargs ip=); do
                 [ -n "$ip" ] \
                     && die "For argument 'ip=$p'\nSorry, setting client-ip does not make sense for '$autoopt'"
                 ;;
+            wicked-static) ;;
             *) die "For argument 'ip=$p'\nSorry, unknown value '$autoopt'" ;;
         esac
     done
@@ -112,7 +113,7 @@ for p in $(getargs ip=); do
         [ -n "$DHCPORSERVER" ] && [ -n "$srv" ] && continue
         # dhcp? (It's simpler to check for a set ip. Checks above ensure that if
         # ip is there, we're static
-        [ -z "$ip" ] && continue
+        [ -z "$ip" -o "$autoopt" = "wicked-static" ] && continue
         # Not good!
         die "Server-ip or dhcp for netboot needed, but current arguments say otherwise"
     fi


### PR DESCRIPTION
Hi,

this introduces the `ip=wicked-static` cmdline option, allowing to apply a static network configuration from the full OS in the initramfs.

**General remarks:**
- Changes to cmdline parameters are not ideal, as they go against the upstream concept of keeping dracut distribution agnostic - unfortunately I did not find an existing way to introduce a static backend - the existing functions and arguments seemed to only cover DHCP as well as static configuration passed using cmdline options.
- I experimented with porting the XML schemas and libraries needed for native Wicked `ifup` functionality to the initramfs, however going the route with this patch, using the existing `do_static` functionality, seemed more lightweight.
- Code style: I did not find any styling guides for dracut. The existing code seemed to be arbitrarily styled - for example in some places there is be a space before semicolons, in other places there isn't, and in some places variables are be quoted, in others they are not. Hence I picked a combination of what seemed like the most common style in the document.

**Functionality remarks:**
- The implementation introduced with this patch only applies the first/primary interface address. Additional IP addresses (`IPADDR_xxx`) are not covered. I deemed the added complexity of iterating over additional addresses not crucial enough for now.
- The implementation covers `/etc/sysconfig/network/ifcfg-*` and `/etc/sysconfig/network/config` files copied upon buildtime. I hope it is clear enough to a user who is reading the manpage, that changes to these files require a run of `mkinitrd` in order for them to be applied to the initramfs.

**Testing remarks:**
I tested this with the following sample `/etc/sysconfig/network/ifcfg-enp1s0` files:
- Test 1 (generated by YaST's LAN module):
```
IPADDR='192.168.5.14/24'
IPADDR_1='2a02:1748:f7df:9c80::aa1/64'
BOOTPROTO='static'
STARTMODE='auto'
LABEL_1='IPv6'
ZONE='public'
```
- Test 2:
```
IPADDR='192.168.5.14'
PREFIXLEN='24'
IPADDR_1='2a02:1748:f7df:9c80::aa1/64'
BOOTPROTO='static'
STARTMODE='auto'
LABEL_1='IPv6'
ZONE='public'
```
- Test 3:
```
IPADDR='192.168.5.14'
NETMASK='255.255.255.0'
IPADDR_1='2a02:1748:f7df:9c80::aa1/64'
BOOTPROTO='static'
STARTMODE='auto'
LABEL_1='IPv6'
ZONE='public'
```
- Test 4:
```
IPADDR_1='192.168.5.14'
PREFIXLEN_1='24'
IPADDR='2a02:1748:f7df:9c80::aa1/64'
BOOTPROTO='static'
STARTMODE='auto'
LABEL_1='IPv4'
ZONE='public'
```
all of them in combination with the following `/etc/sysconfig/network/config` snippet:
```
NETCONFIG_DNS_STATIC_SEARCHLIST="home.lysergic.dev"
NETCONFIG_DNS_STATIC_SERVERS="192.168.5.1 2a02:1748:f7df:9c80::1"
```

I hope to have covered all relevant points.

Best,
Georg
