### PR TITLE
Fix systemd cryptsetup FIDO2 and TPM unlocking (boo#1197638)

### DIFF
--- a/modules.d/91fido2/module-setup.sh
+++ b/modules.d/91fido2/module-setup.sh
@@ -23,6 +23,7 @@ install() {
     inst_libdir_file \
         {"tls/$_arch/",tls/,"$_arch/",}"libfido2.so.*" \
         {"tls/$_arch/",tls/,"$_arch/",}"libcryptsetup.so.*" \
+        {"tls/$_arch/",tls/,"$_arch/",}"/cryptsetup/libcryptsetup-token-systemd-fido2.so" \
         {"tls/$_arch/",tls/,"$_arch/",}"libcbor.so.*" \
         {"tls/$_arch/",tls/,"$_arch/",}"libhidapi-hidraw.so.*"
 }

--- a/modules.d/91tpm2-tss/module-setup.sh
+++ b/modules.d/91tpm2-tss/module-setup.sh
@@ -52,7 +52,7 @@ install() {
         {"tls/$_arch/",tls/,"$_arch/",}"libtss2-tcti-swtpm.so.*" \
         {"tls/$_arch/",tls/,"$_arch/",}"libtss2-tctildr.so.*" \
         {"tls/$_arch/",tls/,"$_arch/",}"libcryptsetup.so.*" \
-        {"tls/$_arch/",tls/,"$_arch/",}"libcryptsetup-token-systemd-tpm2.so.*" \
+        {"tls/$_arch/",tls/,"$_arch/",}"/cryptsetup/libcryptsetup-token-systemd-tpm2.so" \
         {"tls/$_arch/",tls/,"$_arch/",}"libcurl.so.*" \
         {"tls/$_arch/",tls/,"$_arch/",}"libjson-c.so.*"
 

--- a/modules.d/91tpm2-tss/module-setup.sh
+++ b/modules.d/91tpm2-tss/module-setup.sh
@@ -52,6 +52,7 @@ install() {
         {"tls/$_arch/",tls/,"$_arch/",}"libtss2-tcti-swtpm.so.*" \
         {"tls/$_arch/",tls/,"$_arch/",}"libtss2-tctildr.so.*" \
         {"tls/$_arch/",tls/,"$_arch/",}"libcryptsetup.so.*" \
+        {"tls/$_arch/",tls/,"$_arch/",}"libcryptsetup-token-systemd-tpm2.so.*" \
         {"tls/$_arch/",tls/,"$_arch/",}"libcurl.so.*" \
         {"tls/$_arch/",tls/,"$_arch/",}"libjson-c.so.*"
 


### PR DESCRIPTION
Backport https://github.com/dracutdevs/dracut/pull/1677 to fix automatic cryptsetup unlocking with systemd 250+.