### PR TITLE
fix(dracut-initramfs-restore.sh): unpack uncompressed initrd as last option (bsc#1197195)

### DIFF
--- a/dracut-initramfs-restore.sh
+++ b/dracut-initramfs-restore.sh
@@ -51,13 +51,13 @@ fi
 
 cd /run/initramfs
 
-if $SKIP "$IMG" | cpio -id --no-absolute-filenames --quiet > /dev/null \
-    || $SKIP "$IMG" | zcat | cpio -id --no-absolute-filenames --quiet > /dev/null \
+if $SKIP "$IMG" | zcat | cpio -id --no-absolute-filenames --quiet > /dev/null \
     || $SKIP "$IMG" | bzcat | cpio -id --no-absolute-filenames --quiet > /dev/null \
     || $SKIP "$IMG" | xzcat | cpio -id --no-absolute-filenames --quiet > /dev/null \
     || $SKIP "$IMG" | lz4 -d -c | cpio -id --no-absolute-filenames --quiet > /dev/null \
     || $SKIP "$IMG" | lzop -d -c | cpio -id --no-absolute-filenames --quiet > /dev/null \
-    || $SKIP "$IMG" | zstd -d -c | cpio -id --no-absolute-filenames --quiet > /dev/null; then
+    || $SKIP "$IMG" | zstd -d -c | cpio -id --no-absolute-filenames --quiet > /dev/null \
+    || $SKIP "$IMG" | cpio -id --no-absolute-filenames --quiet > /dev/null; then
     rm -f -- .need_shutdown
 else
     # something failed, so we clean up


### PR DESCRIPTION
Attempting to unpack the initrd assuming it is not compressed when
it is delays the shutdown process by several seconds. This must
be the last check.

(cherry picked from commit 46886956211f8a436e2e9f81fc4972d2a297c3a3)

bsc#1197195