### PR TITLE
fix(crypt): remove quotes from cryptsetupopts (bsc#1197635)

### DIFF
--- a/modules.d/90crypt/cryptroot-ask.sh
+++ b/modules.d/90crypt/cryptroot-ask.sh
@@ -138,8 +138,9 @@ unset allowdiscards
 ask_passphrase=1
 
 if [ -n "$luksfile" -a "$luksfile" != "none" -a -e "$luksfile" ]; then
+    # shellcheck disable=SC2086
     if readkey "$luksfile" / "$device" \
-        | cryptsetup -d - "$cryptsetupopts" luksOpen "$device" "$luksname"; then
+        | cryptsetup -d - $cryptsetupopts luksOpen "$device" "$luksname"; then
         ask_passphrase=0
     fi
 elif [ "$is_keysource" -ne 0 ]; then
@@ -164,8 +165,9 @@ else
         unset tmp
 
         info "Using '$keypath' on '$keydev'"
+        # shellcheck disable=SC2086
         readkey "$keypath" "$keydev" "$device" \
-            | cryptsetup -d - "$cryptsetupopts" luksOpen "$device" "$luksname" \
+            | cryptsetup -d - $cryptsetupopts luksOpen "$device" "$luksname" \
             && ask_passphrase=0
         unset keypath keydev
         break


### PR DESCRIPTION
Fixes #1528.

(cherry picked from commit e0abf88a15d23fbf793cf872397016ad86aeaaa8)