### PR TITLE
fix(bluetooth): make $dbussystem/bluetooth.conf optional (bsc#1195047)

### DIFF
--- a/modules.d/62bluetooth/module-setup.sh
+++ b/modules.d/62bluetooth/module-setup.sh
@@ -55,7 +55,7 @@ install() {
     shopt -q -s nullglob globstar
     local -a var_lib_files
 
-    inst_multiple \
+    inst_multiple -o \
         "$dbussystem"/bluetooth.conf \
         "${systemdsystemunitdir}/bluetooth.target" \
         "${systemdsystemunitdir}/bluetooth.service" \


### PR DESCRIPTION
Do not display an error message if `$dbussystem/bluetooth.conf` file don't exist.

(cherry picked from commit a38d9ec0320f3819a3b70dc5bb59f6d2fc570149)