### PR TITLE
fix(dracut-install): copy files preserving ownership attributes (bsc#1197967)

### DIFF
--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -328,10 +328,10 @@ normal_copy:
         pid = fork();
         if (pid == 0) {
                 if (geteuid() == 0 && no_xattr == false)
-                        execlp("cp", "cp", "--reflink=auto", "--sparse=auto", "--preserve=mode,xattr,timestamps", "-fL",
+                        execlp("cp", "cp", "--reflink=auto", "--sparse=auto", "--preserve=mode,xattr,timestamps,ownership", "-fL",
                                src, dst, NULL);
                 else
-                        execlp("cp", "cp", "--reflink=auto", "--sparse=auto", "--preserve=mode,timestamps", "-fL", src,
+                        execlp("cp", "cp", "--reflink=auto", "--sparse=auto", "--preserve=mode,timestamps,ownership", "-fL", src,
                                dst, NULL);
                 _exit(EXIT_FAILURE);
         }
@@ -340,10 +340,10 @@ normal_copy:
                 if (errno != EINTR) {
                         ret = -1;
                         if (geteuid() == 0 && no_xattr == false)
-                                log_error("Failed: cp --reflink=auto --sparse=auto --preserve=mode,xattr,timestamps -fL %s %s",
+                                log_error("Failed: cp --reflink=auto --sparse=auto --preserve=mode,xattr,timestamps,ownership -fL %s %s",
                                           src, dst);
                         else
-                                log_error("Failed: cp --reflink=auto --sparse=auto --preserve=mode,timestamps -fL %s %s",
+                                log_error("Failed: cp --reflink=auto --sparse=auto --preserve=mode,timestamps,ownership -fL %s %s",
                                           src, dst);
                         break;
                 }


### PR DESCRIPTION
While the "clone copy" operation changes the ownership of the cloned
files, the "normal copy" using cp does not preserve it.

(cherry picked from commit 9ef73b6ad08c19c3906564e5a15c7908ed9a81c8)