### PR TITLE
chore(suse): remove fipscheck requirement (bsc#1198065) (SLE15-SP4:GA)

### DIFF
--- a/suse/dracut.spec
+++ b/suse/dracut.spec
@@ -80,7 +80,6 @@ NFS, iSCSI, NBD, FCoE.
 Summary:        Dracut modules to build a dracut initramfs with an integrity check
 Group:          System/Base
 Requires:       %{name} = %{version}-%{release}
-Requires:       fipscheck
 Requires:       libcryptsetup12-hmac
 Requires:       libgcrypt20-hmac
 Requires:       libkcapi-tools


### PR DESCRIPTION
Do not require the OpenSSL based `fipscheck`. Use the `libkcapi-tools` based `fipscheck`.