### PR TITLE
fix(lvm): add missing grep requirement (bsc#1198271)

### DIFF
--- a/modules.d/90lvm/module-setup.sh
+++ b/modules.d/90lvm/module-setup.sh
@@ -3,7 +3,7 @@
 # called by dracut
 check() {
     # No point trying to support lvm if the binaries are missing
-    require_binaries lvm || return 1
+    require_binaries lvm grep || return 1
 
     [[ $hostonly ]] || [[ $mount_needs ]] && {
         for fs in "${host_fs_types[@]}"; do
@@ -48,7 +48,7 @@ installkernel() {
 
 # called by dracut
 install() {
-    inst lvm
+    inst_multiple lvm grep
 
     if [[ $hostonly_cmdline == "yes" ]]; then
         local _lvmconf


### PR DESCRIPTION
Since commit https://github.com/dracutdevs/dracut/commit/7ffc5e38 `lvm_scan.sh` needs `grep`.

(cherry picked from commit 79f9d9e1c29a9c8fc046ab20765e5bde2aaa3428)