### PR TITLE
fix(resume): correct call to block_is_netdevice function (bsc#1197737)

### DIFF
--- a/modules.d/95resume/module-setup.sh
+++ b/modules.d/95resume/module-setup.sh
@@ -5,7 +5,7 @@ check() {
     swap_on_netdevice() {
         local _dev
         for _dev in "${swap_devs[@]}"; do
-            block_is_netdevice "$_dev" && return 0
+            block_is_netdevice "$(get_maj_min "$_dev")" && return 0
         done
         return 1
     }


### PR DESCRIPTION
The `block_is_netdevice` function requires the device in <maj:min>
format, but the `swap_devs` array is populated with the content of
/proc/swaps, which prints the devices using their paths from /dev.

This causes the check method to never detect if swap is mounted on a
network device.

(cherry picked from commit a7a4b76c4ad5794f5f8a24ecd5b495f1512d05f7)