### PR TITLE
fix(resume): do not add this module if there is no suitable swap (bsc#1198095)

### DIFF
--- a/modules.d/95resume/module-setup.sh
+++ b/modules.d/95resume/module-setup.sh
@@ -10,8 +10,10 @@ check() {
         return 1
     }
 
-    # Only support resume if no swap is mounted on a net device
+    # Only support resume if there is any suitable swap and
+    # it is not mounted on a net device
     [[ $hostonly ]] || [[ $mount_needs ]] && {
+        ((${#swap_devs[@]})) || return 1
         # sanity check: do not add the resume module if there is a
         # resume argument pointing to a non existent disk or to a
         # volatile swap


### PR DESCRIPTION
- Do not add the resume module if there is no suitable swap.

If the `swap_devs` array is empty the resume module is added anyway.

Even if the system only has a swap partition encrypted using a volatile random key, it is not added to the `swap_devs` array, so
it is empty, but the resume module is added.

- Improve sanity check of resume module.

Do not add the resume module if the kernel command line contains a `resume=` argument pointing to a volatile swap.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
