### PR TITLE
fix(resume): do not add this module if there is no suitable swap (bsc#1198095) (055)

### DIFF
--- a/modules.d/95resume/module-setup.sh
+++ b/modules.d/95resume/module-setup.sh
@@ -10,8 +10,10 @@ check() {
         return 1
     }
 
-    # Only support resume if no swap is mounted on a net device
+    # Only support resume if there is any suitable swap and
+    # it is not mounted on a net device
     [[ $hostonly ]] || [[ $mount_needs ]] && {
+        ((${#swap_devs[@]})) || return 1
         swap_on_netdevice && return 255
     }
 


### PR DESCRIPTION
If the `swap_devs` array is empty the resume module is added anyway.

Even if the system only has a swap partition encrypted using a
volatile random key, it is not added to the `swap_devs` array, so
it is empty, but the resume module is added.
