### PR TITLE
detect correct initrd location for systemd-boot (boo#1198681)

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1062,7 +1062,9 @@ if ! [[ $outfile ]]; then
         mkdir -p "$dracutsysrootdir$efidir/Linux"
         outfile="$dracutsysrootdir$efidir/Linux/linux-$kernel${MACHINE_ID:+-${MACHINE_ID}}${BUILD_ID:+-${BUILD_ID}}.efi"
     else
-        if [[ -e "$dracutsysrootdir/boot/initrd-$kernel" ]]; then
+        if [[ -d "$dracutsysrootdir/boot/efi/${MACHINE_ID}" ]]; then
+            outfile="/boot/efi/${MACHINE_ID}/$kernel/initrd"
+        elif [[ -e "$dracutsysrootdir/boot/initrd-$kernel" ]]; then
             outfile="/boot/initrd-$kernel"
         elif [[ $MACHINE_ID ]] && { [[ -d $dracutsysrootdir/boot/${MACHINE_ID} ]] || [[ -L $dracutsysrootdir/boot/${MACHINE_ID} ]]; }; then
             outfile="$dracutsysrootdir/boot/${MACHINE_ID}/$kernel/initrd"

--- a/suse/mkinitrd-suse.sh
+++ b/suse/mkinitrd-suse.sh
@@ -301,6 +301,14 @@ while (($# > 0)); do
     shift
 done
 
+if [ -e /etc/machine-id ]; then
+    read -r MACHINE_ID < /etc/machine-id
+    if [ -d "$boot_dir/efi/$MACHINE_ID" ]; then
+	error "Looks like systemd-boot is installed. mkinitrd won't work here. Use dracut directly instead."
+	exit 1
+    fi
+fi
+
 [[ $targets && $kernels ]] || default_kernel_images
 if [[ ! $targets || ! $kernels ]];then
     error "No kernel found in $boot_dir or bad modules dir in /lib/modules"


### PR DESCRIPTION
This pull request changes...

When using systemd-boot (https://en.opensuse.org/Systemd-boot) and kernel-install, dracut runs a hook script to generate the initrd at the correct place in the ESP:
https://github.com/openSUSE/dracut/blob/SUSE/056/install.d/50-dracut.install

However, when calling dracut (or mkinitrd) manually they place the initrd in the traditional place in /boot. There is some autodetection taking place that doesn't notice boot loader spec installation.

## Changes

## Checklist
- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
https://bugzilla.opensuse.org/show_bug.cgi?id=1198681