### PR TITLE
fix(nfs): give /run/rpcbind ownership to rpc user (bsc#1177461)

### DIFF
--- a/modules.d/95nfs/module-setup.sh
+++ b/modules.d/95nfs/module-setup.sh
@@ -21,7 +21,7 @@ get_nfs_type() {
 check() {
     # If our prerequisites are not met, fail anyways.
     require_any_binary rpcbind portmap || return 1
-    require_binaries rpc.statd mount.nfs mount.nfs4 umount || return 1
+    require_binaries rpc.statd mount.nfs mount.nfs4 umount sed chmod chown || return 1
 
     [[ $hostonly ]] || [[ $mount_needs ]] && {
         [[ "$(get_nfs_type)" ]] && return 0
@@ -76,7 +76,7 @@ cmdline() {
 # called by dracut
 install() {
     local _nsslibs
-    inst_multiple -o rpc.idmapd mount.nfs mount.nfs4 umount sed /etc/netconfig chmod "$tmpfilesdir/rpcbind.conf"
+    inst_multiple -o rpc.idmapd mount.nfs mount.nfs4 umount sed /etc/netconfig chmod chown "$tmpfilesdir/rpcbind.conf"
     inst_multiple -o /etc/idmapd.conf
     inst_multiple -o /etc/services /etc/nsswitch.conf /etc/rpc /etc/protocols
     inst_multiple -o /usr/etc/services /usr/etc/nsswitch.conf /usr/etc/rpc /usr/etc/protocols

--- a/modules.d/95nfs/nfs-start-rpc.sh
+++ b/modules.d/95nfs/nfs-start-rpc.sh
@@ -9,6 +9,7 @@ if modprobe sunrpc || strstr "$(cat /proc/filesystems)" rpc_pipefs; then
     command -v portmap > /dev/null && [ -z "$(pidof portmap)" ] && portmap
     if command -v rpcbind > /dev/null && [ -z "$(pidof rpcbind)" ]; then
         mkdir -p /run/rpcbind
+        chown rpc:rpc /run/rpcbind
         rpcbind
     fi
 


### PR DESCRIPTION
Avoid errors when rpcbind tries to write to the /run/rpcbind directory.

(cherry picked from commit https://github.com/openSUSE/dracut/commit/d615934311e25146bb37943bf1385a19dfdbd9e8)

