### PR TITLE
fix(nfs): give /run/rpcbind ownership to rpc user (bsc#1177461) (049)

### DIFF
--- a/modules.d/95nfs/nfs-start-rpc.sh
+++ b/modules.d/95nfs/nfs-start-rpc.sh
@@ -11,6 +11,7 @@ if modprobe sunrpc || strstr "$(cat /proc/filesystems)" rpc_pipefs; then
     command -v portmap >/dev/null && [ -z "$(pidof portmap)" ] && portmap
     if command -v rpcbind >/dev/null && [ -z "$(pidof rpcbind)" ]; then
         mkdir -p /run/rpcbind
+        chown rpc:rpc /run/rpcbind
         rpcbind
     fi
 


### PR DESCRIPTION
Avoid errors when rpcbind tries to write to the /run/rpcbind directory.

(cherry picked from commit d615934311e25146bb37943bf1385a19dfdbd9e8)
