### PR TITLE
fix(nfs): /var is not mounted during the transactional-update run (bsc#1184970) (055)

### DIFF
--- a/modules.d/95nfs/module-setup.sh
+++ b/modules.d/95nfs/module-setup.sh
@@ -120,8 +120,7 @@ install() {
     mkdir -m 0755 -p "$initdir/var/lib/nfs"
     mkdir -m 0755 -p "$initdir/var/lib/nfs/rpc_pipefs"
     mkdir -m 0770 -p "$initdir/var/lib/rpcbind"
-    [ -d "/var/lib/nfs/statd/sm" ] && mkdir -m 0755 -p "$initdir/var/lib/nfs/statd/sm"
-    [ -d "/var/lib/nfs/sm" ] && mkdir -m 0755 -p "$initdir/var/lib/nfs/sm"
+    mkdir -m 0755 -p "$initdir/var/lib/nfs/sm"
 
     # Rather than copy the passwd file in, just set a user for rpcbind
     # We'll save the state and restart the daemon from the root anyway


### PR DESCRIPTION
Due to the volatile nature of /var the directory will not be mounted
into the new snapshot during the transactional-update run, as this
would break atomicity.

Therefore, any condition during the initrd generation related to the
existence of any file or directory under /var will fail.