### PR TITLE
fix(resume): relax exclusion check (bsc#1198554)

### DIFF
--- a/modules.d/95resume/module-setup.sh
+++ b/modules.d/95resume/module-setup.sh
@@ -13,7 +13,6 @@ check() {
     # Only support resume if there is any suitable swap and
     # it is not mounted on a net device
     [[ $hostonly ]] || [[ $mount_needs ]] && {
-        ((${#swap_devs[@]})) || return 1
         # sanity check: do not add the resume module if there is a
         # resume argument pointing to a non existent disk or to a
         # volatile swap
@@ -36,6 +35,7 @@ check() {
                 fi
             fi
         fi
+        ((${#swap_devs[@]})) || return 255
         swap_on_netdevice && return 255
     }
 


### PR DESCRIPTION
The `swap_devs` array is populated only with swap devices specified in
`/etc/fstab`, but this shouldn't be a hard requirement to add the
resume module.
