### PR TITLE
fix(resume): relax exclusion check (bsc#1198554) (055)

### DIFF
--- a/modules.d/95resume/module-setup.sh
+++ b/modules.d/95resume/module-setup.sh
@@ -13,7 +13,7 @@ check() {
     # Only support resume if there is any suitable swap and
     # it is not mounted on a net device
     [[ $hostonly ]] || [[ $mount_needs ]] && {
-        ((${#swap_devs[@]})) || return 1
+        ((${#swap_devs[@]})) || return 255
         swap_on_netdevice && return 255
     }
 


### PR DESCRIPTION
The `swap_devs` array is populated only with swap devices specified in
`/etc/fstab`, but this shouldn't be a hard requirement to add the
resume module.