### PR TITLE
Add missing dracut default output files (boo#1198681)

### DIFF
--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -109,7 +109,13 @@ if [[ $1 ]]; then
         exit 1
     fi
 else
-    [[ -f /etc/machine-id ]] && read -r MACHINE_ID < /etc/machine-id
+    if [[ -d /efi/Default ]] || [[ -d /boot/Default ]] || [[ -d /boot/efi/Default ]]; then
+        MACHINE_ID="Default"
+    elif [[ -f /etc/machine-id ]]; then
+        read -r MACHINE_ID < /etc/machine-id
+    else
+        MACHINE_ID="Default"
+    fi
 
     if [[ -d /efi/loader/entries || -L /efi/loader/entries ]] \
         && [[ $MACHINE_ID ]] \
@@ -119,8 +125,20 @@ else
         && [[ $MACHINE_ID ]] \
         && [[ -d /boot/${MACHINE_ID} || -L /boot/${MACHINE_ID} ]]; then
         image="/boot/${MACHINE_ID}/${KERNEL_VERSION}/initrd"
-    else
+    elif [[ -d /boot/efi/loader/entries || -L /boot/efi/loader/entries ]] \
+        && [[ $MACHINE_ID ]] \
+        && [[ -d /boot/efi/${MACHINE_ID} || -L /boot/efi/${MACHINE_ID} ]]; then
+        image="/boot/efi/${MACHINE_ID}/${KERNEL_VERSION}/initrd"
+    elif [[ -f /lib/modules/${KERNEL_VERSION}/initrd ]]; then
+        image="/lib/modules/${KERNEL_VERSION}/initrd"
+    elif [[ -f /boot/initrd-${KERNEL_VERSION} ]]; then
         image="/boot/initrd-${KERNEL_VERSION}"
+    elif mountpoint -q /efi; then
+        image="/efi/${MACHINE_ID}/${KERNEL_VERSION}/initrd"
+    elif mountpoint -q /boot/efi; then
+        image="/boot/efi/${MACHINE_ID}/${KERNEL_VERSION}/initrd"
+    else
+        image=""
     fi
 fi
 

--- a/man/dracut.8.asc
+++ b/man/dracut.8.asc
@@ -18,8 +18,13 @@ DESCRIPTION
 
 Create an initramfs <image> for the kernel with the version <kernel version>.
 If <kernel version> is omitted, then the version of the actual running
-kernel is used. If <image> is omitted or empty, then the default location
-/boot/initramfs-<kernel version>.img is used.
+kernel is used. If <image> is omitted or empty, depending on bootloader
+specification, the default location can be
+_/efi/<machine-id>/<kernel-version>/initrd_,
+_/boot/<machine-id>/<kernel-version>/initrd_,
+_/boot/efi/<machine-id>/<kernel-version>/initrd_,
+_/lib/modules/<kernel-version>/initrd_ or
+_/boot/initrd-<kernel-version>_.
 
 dracut creates an initial image used by the kernel for preloading the block
 device modules (such as IDE, SCSI or RAID) which are needed to access the root

--- a/man/dracut.usage.asc
+++ b/man/dracut.usage.asc
@@ -5,9 +5,13 @@ To create a initramfs image, the most simple command is:
 
 This will generate a general purpose initramfs image, with all possible
 functionality resulting of the combination of the installed dracut modules and
-system tools. The image is /boot/initramfs-_++<kernel version>++_.img and
-contains the kernel modules of the currently active kernel with version
-_++<kernel version>++_.
+system tools. The image, depending on bootloader specification, can be
+_/efi/_++<machine-id>++_/_++<kernel-version>++_/initrd_,
+_/boot/_++<machine-id>++_/_++<kernel-version>++_/initrd_,
+_/boot/efi/_++<machine-id>++_/_++<kernel-version>++_/initrd_,
+_/lib/modules/_++<kernel-version>++_/initrd_ or
+_/boot/initrd-_++<kernel-version>++_,_ and contains the kernel modules of
+the currently active kernel with version _++<kernel-version>++_.
 
 If the initramfs image already exists, dracut will display an error message, and
 to overwrite the existing image, you have to use the --force option.

--- a/man/lsinitrd.1.asc
+++ b/man/lsinitrd.1.asc
@@ -13,13 +13,16 @@ SYNOPSIS
 --------
 *lsinitrd* ['OPTION...'] [<image> [<filename> [<filename> [...] ]]]
 
-*lsinitrd* ['OPTION...'] -k <kernel-version>
+*lsinitrd* ['OPTION...'] -k <kernel version>
 
 DESCRIPTION
 -----------
 lsinitrd shows the contents of an initramfs image. if <image> is omitted, then
-lsinitrd uses the default image _/boot/<machine-id>/<kernel-version>/initrd_ or
-_/boot/initramfs-<kernel-version>.img_.
+lsinitrd uses the default image _/efi/<machine-id>/<kernel-version>/initrd_,
+_/boot/<machine-id>/<kernel-version>/initrd_,
+_/boot/efi/<machine-id>/<kernel-version>/initrd_,
+_/lib/modules/<kernel-version>/initrd_ or
+_/boot/initrd-<kernel-version>_.
 
 OPTIONS
 -------

--- a/suse/mkinitrd-suse.sh
+++ b/suse/mkinitrd-suse.sh
@@ -301,6 +301,14 @@ while (($# > 0)); do
     shift
 done
 
+if [ -e /etc/machine-id ]; then
+    read -r MACHINE_ID < /etc/machine-id
+    if [ -d "$boot_dir/efi/$MACHINE_ID" ]; then
+	error "Looks like systemd-boot is installed. mkinitrd won't work here. Use dracut directly instead."
+	exit 1
+    fi
+fi
+
 [[ $targets && $kernels ]] || default_kernel_images
 if [[ ! $targets || ! $kernels ]];then
     error "No kernel found in $boot_dir or bad modules dir in /lib/modules"


### PR DESCRIPTION
Follows #173 using a larger scope (https://github.com/dracutdevs/dracut/pull/1786).

When using systemd-boot and kernel-install, dracut runs a hook script (install.d/50-dracut.install) to generate the initrd at the correct place in the ESP. However, when calling dracut manually the initrd is saved in the traditional place in /boot. The same happens with lsinitrd, it does not detect the default initrd.

Fix the auto detection that doesn't notice the bootloader spec installation.

## Checklist
- [X] I have tested it locally
- [X] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
