### PR TITLE
feat(resume): sanity check (SLE15-SP4:GA)

### DIFF
--- a/modules.d/95resume/module-setup.sh
+++ b/modules.d/95resume/module-setup.sh
@@ -12,6 +12,17 @@ check() {
 
     # Only support resume if no swap is mounted on a net device
     [[ $hostonly ]] || [[ $mount_needs ]] && {
+        # sanity check: do not add the resume module if there is a
+        # resume argument pointing to a non existent disk
+        local _resume
+        _resume=$(getarg resume=)
+        if [ -n "$_resume" ]; then
+            _resume="$(label_uuid_to_dev "$_resume")"
+            if [ ! -e "$_resume" ]; then
+                derror "Current resume kernel argument points to an invalid disk"
+                return 255
+            fi
+        fi
         swap_on_netdevice && return 255
     }
 

--- a/modules.d/95resume/module-setup.sh
+++ b/modules.d/95resume/module-setup.sh
@@ -10,7 +10,8 @@ check() {
         return 1
     }
 
-    # Only support resume if no swap is mounted on a net device
+    # Only support resume if there is any suitable swap and
+    # it is not mounted on a net device
     [[ $hostonly ]] || [[ $mount_needs ]] && {
         # sanity check: do not add the resume module if there is a
         # resume argument pointing to a non existent disk or to a
@@ -34,6 +35,7 @@ check() {
                 fi
             fi
         fi
+        ((${#swap_devs[@]})) || return 255
         swap_on_netdevice && return 255
     }
 

--- a/suse/dracut.spec
+++ b/suse/dracut.spec
@@ -176,6 +176,9 @@ mv %{buildroot}/%{dracutlibdir}/modules.d/45ifcfg/write-ifcfg.sh %{buildroot}/%{
 ln -s %{dracutlibdir}/modules.d/45ifcfg/write-ifcfg-redhat.sh %{buildroot}/%{dracutlibdir}/modules.d/45ifcfg/write-ifcfg.sh
 %endif
 
+# create a link to dracut-util to be able to parse kernel command line arguments at generation time
+ln -s %{dracutlibdir}/dracut-util %{buildroot}/%{dracutlibdir}/dracut-getarg
+
 %post
 # check whether /var/run has been converted to a symlink
 if [ ! -L /var/run ]; then
@@ -311,6 +314,7 @@ fi
 %{dracutlibdir}/dracut-initramfs-restore
 %{dracutlibdir}/dracut-install
 %{dracutlibdir}/dracut-util
+%{dracutlibdir}/dracut-getarg
 %{dracutlibdir}/dracut-cpio
 
 %dir %{dracutlibdir}/modules.d


### PR DESCRIPTION
- Do not break a previously existing system with a possibly invalid `resume=` command line (basically any system installed using an old yast clone profile, and possibly machines that have not maintained their boot parameters over time).
- Do not add the resume module if the kernel command line contains a `resume=` argument pointing to a volatile swap.
- Do not add the resume module if the `swap_devs` array is empty. E.g.: system with only a swap partition encrypted using a volatile random key, it is not added to the `swap_devs` array, so it is empty, but the resume module is being added anyway.