### PR TITLE
feat(resume): sanity check (055)

### DIFF
--- a/modules.d/95resume/module-setup.sh
+++ b/modules.d/95resume/module-setup.sh
@@ -13,6 +13,17 @@ check() {
     # Only support resume if there is any suitable swap and
     # it is not mounted on a net device
     [[ $hostonly ]] || [[ $mount_needs ]] && {
+        # sanity check: do not add the resume module if there is a
+        # resume argument pointing to a non existent disk
+        local _resume
+        _resume=$(getarg resume=)
+        if [ -n "$_resume" ]; then
+            _resume="$(label_uuid_to_dev "$_resume")"
+            if [ ! -e "$_resume" ]; then
+                derror "Current resume kernel argument points to an invalid disk"
+                return 255
+            fi
+        fi
         ((${#swap_devs[@]})) || return 255
         swap_on_netdevice && return 255
     }

--- a/modules.d/95resume/module-setup.sh
+++ b/modules.d/95resume/module-setup.sh
@@ -14,7 +14,8 @@ check() {
     # it is not mounted on a net device
     [[ $hostonly ]] || [[ $mount_needs ]] && {
         # sanity check: do not add the resume module if there is a
-        # resume argument pointing to a non existent disk
+        # resume argument pointing to a non existent disk or to a
+        # volatile swap
         local _resume
         _resume=$(getarg resume=)
         if [ -n "$_resume" ]; then
@@ -22,6 +23,16 @@ check() {
             if [ ! -e "$_resume" ]; then
                 derror "Current resume kernel argument points to an invalid disk"
                 return 255
+            fi
+            if [[ "$_resume" == /dev/mapper/* ]]; then
+                if [[ -f "$dracutsysrootdir"/etc/crypttab ]]; then
+                    local _mapper _opts
+                    read -r _mapper _ _ _opts < <(grep -m1 -w "^${_resume#/dev/mapper/}" "$dracutsysrootdir"/etc/crypttab)
+                    if [[ -n "$_mapper" ]] && [[ "$_opts" == *swap* ]]; then
+                        derror "Current resume kernel argument points to a volatile swap"
+                        return 255
+                    fi
+                fi
             fi
         fi
         ((${#swap_devs[@]})) || return 255

--- a/suse/dracut.spec
+++ b/suse/dracut.spec
@@ -176,6 +176,9 @@ mv %{buildroot}/%{dracutlibdir}/modules.d/45ifcfg/write-ifcfg.sh %{buildroot}/%{
 ln -s %{dracutlibdir}/modules.d/45ifcfg/write-ifcfg-redhat.sh %{buildroot}/%{dracutlibdir}/modules.d/45ifcfg/write-ifcfg.sh
 %endif
 
+# create a link to dracut-util to be able to parse kernel command line arguments at generation time
+ln -s %{dracutlibdir}/dracut-util %{buildroot}/%{dracutlibdir}/dracut-getarg
+
 %post
 # check whether /var/run has been converted to a symlink
 if [ ! -L /var/run ]; then
@@ -311,6 +314,7 @@ fi
 %{dracutlibdir}/dracut-initramfs-restore
 %{dracutlibdir}/dracut-install
 %{dracutlibdir}/dracut-util
+%{dracutlibdir}/dracut-getarg
 %{dracutlibdir}/dracut-cpio
 
 %dir %{dracutlibdir}/modules.d


### PR DESCRIPTION
- Do not break a previously existing system with a possibly invalid `resume=` command line (basically any system installed using an old yast clone profile, and possibly machines that have not maintained their boot parameters over time).
- Do not add the resume module if the kernel command line contains a `resume=` argument pointing to a volatile swap.