### PR TITLE
fix(dracut.sh): remove some default paths (bsc#1199051)

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1082,16 +1082,8 @@ if ! [[ $outfile ]]; then
             && [[ $MACHINE_ID ]] \
             && [[ -d "$dracutsysrootdir"/boot/efi/${MACHINE_ID} || -L "$dracutsysrootdir"/boot/efi/${MACHINE_ID} ]]; then
             outfile="$dracutsysrootdir/boot/efi/${MACHINE_ID}/${kernel}/initrd"
-        elif [[ -f "$dracutsysrootdir"/lib/modules/${kernel}/initrd ]]; then
-            outfile="$dracutsysrootdir/lib/modules/${kernel}/initrd"
-        elif [[ -e $dracutsysrootdir/boot/initrd-${kernel} ]]; then
-            outfile="$dracutsysrootdir/boot/initrd-${kernel}"
-        elif [[ -z $dracutsysrootdir ]] && mountpoint -q /efi; then
-            outfile="/efi/${MACHINE_ID}/${kernel}/initrd"
-        elif [[ -z $dracutsysrootdir ]] && mountpoint -q /boot/efi; then
-            outfile="/boot/efi/${MACHINE_ID}/${kernel}/initrd"
         else
-            outfile="$dracutsysrootdir/boot/initrd-$kernel"
+            outfile="$dracutsysrootdir/boot/initrd-${kernel}"
         fi
     fi
 fi


### PR DESCRIPTION
Some default paths that check only if a EFI mount point is defined
cause problems in SUSE installations that do not have an initrd
created yet, because the installation process expects that dracut
creates the default `/boot/initrd-<kernel-version>`.

Removing all default paths that are not needed for SUSE is "playing
safe", though upstream approach of checking that MACHINE_ID is not
empty should be enough.