### PR TITLE
fix(integrity): do not display any error if there is no IMA certificate (bsc#1187654) (055)

### DIFF
--- a/modules.d/98integrity/ima-keys-load.sh
+++ b/modules.d/98integrity/ima-keys-load.sh
@@ -17,8 +17,7 @@ load_x509_keys() {
         IMAKEYSDIR="/etc/keys/ima"
     fi
 
-    PUBKEY_LIST=$(ls "${NEWROOT}"${IMAKEYSDIR}/*)
-    for PUBKEY in ${PUBKEY_LIST}; do
+    for PUBKEY in "${NEWROOT}${IMAKEYSDIR}"/*; do
         # check for public key's existence
         if [ ! -f "${PUBKEY}" ]; then
             if [ "${RD_DEBUG}" = "yes" ]; then


### PR DESCRIPTION
IMA appraisal can be used without digital signatures, just by storing hash
digests instead.

(cherry picked from commit f63f411d52df613936082d646ab072447b8b9d7f)