### PR TITLE
fix(i18n): add required includes for keymaps (bsc#1200950)

### DIFF
--- a/modules.d/10i18n/module-setup.sh
+++ b/modules.d/10i18n/module-setup.sh
@@ -63,7 +63,9 @@ install() {
             readarray -t INCLUDES < <("$CMD" '^include ' "$MAP" | while read -r _ a _ || [ -n "$a" ]; do echo "${a//\"/}"; done)
 
             for INCL in "${INCLUDES[@]}"; do
-                for FN in "$dracutsysrootdir""${kbddir}"/keymaps/**/"$INCL"*; do
+                local -a FNS
+                mapfile -t -d '' FNS < <(find "${dracutsysrootdir}${kbddir}"/keymaps/ -type f -name "${INCL}*" -print0)
+                for FN in "${FNS[@]}"; do
                     [[ -f $FN ]] || continue
                     [[ -v KEYMAPS["$FN"] ]] || findkeymap "$FN"
                 done


### PR DESCRIPTION
Commit https://github.com/dracutdevs/dracut/commit/f3441cc7 removed shell
options but didn't adapt all the code that requires nullglob and globstar.
This caused the initrd to be generated without the required includes for
keymaps.