### PR TITLE
fix(network-legacy): add auto timeout to wicked DHCP test (bsc#1198709) (055)

### DIFF
--- a/modules.d/35network-legacy/module-setup.sh
+++ b/modules.d/35network-legacy/module-setup.sh
@@ -12,6 +12,7 @@ check() {
 
 # called by dracut
 depends() {
+    echo bash
     return 0
 }
 


### PR DESCRIPTION
Add an automatic timeout value to wicked DHCP test if NFS, FCoE, or iSCSI
devices are used for booting.