### PR TITLE
fix(fips): add missing bash dependency

### DIFF
--- a/modules.d/01fips/module-setup.sh
+++ b/modules.d/01fips/module-setup.sh
@@ -7,6 +7,7 @@ check() {
 
 # called by dracut
 depends() {
+    echo bash
     return 0
 }
 


### PR DESCRIPTION
`fips.sh` requires bash