### PR TITLE
fix(network-legacy): properly install dhclient

### DIFF
--- a/modules.d/35network-legacy/module-setup.sh
+++ b/modules.d/35network-legacy/module-setup.sh
@@ -31,7 +31,7 @@ install() {
     fi
 
     inst_multiple ip sed awk grep pgrep tr expr
-    inst_simple -o dhclient
+    inst -o dhclient
 
     inst_multiple -o arping arping2
     if command -v arping > /dev/null; then


### PR DESCRIPTION
`inst_simple` cannot be used to install the dhclient binary because it does not
resolve dependencies.

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
