### PR TITLE
fix(network-legacy): check if dhclient has --timeout option

### DIFF
--- a/man/dracut.cmdline.7.asc
+++ b/man/dracut.cmdline.7.asc
@@ -740,7 +740,7 @@ NFS
     Default is 1.
 
 **rd.net.timeout.dhcp=**__<arg>__::
-    If this option is set, dhclient is called with "-timeout <arg>".
+    If this option is set, dhclient is called with "--timeout <arg>".
 
 **rd.net.timeout.iflink=**__<seconds>__::
     Wait <seconds> until link shows up. Default is 60 seconds.

--- a/modules.d/35network-legacy/dhcp-multi.sh
+++ b/modules.d/35network-legacy/dhcp-multi.sh
@@ -21,6 +21,13 @@ do_dhclient() {
     _timeout=$(getarg rd.net.timeout.dhcp=)
     _DHCPRETRY=$(getargnum 1 1 1000000000 rd.net.dhcp.retry=)
 
+    if [ -n "$_timeout" ]; then
+        if ! (dhclient --help 2>&1 | grep -q -F -- '--timeout' 2> /dev/null); then
+            warn "rd.net.timeout.dhcp has no effect because dhclient does not implement the --timeout option"
+            unset _timeout
+        fi
+    fi
+
     while [ $_COUNT -lt "$_DHCPRETRY" ]; do
         info "Starting dhcp for interface $netif"
         dhclient "$arg" \

--- a/modules.d/35network-legacy/ifup.sh
+++ b/modules.d/35network-legacy/ifup.sh
@@ -134,6 +134,13 @@ dhcp_wicked_read_ifcfg() {
 
 
 dhcp_dhclient_run() {
+    if [ -n "$_timeout" ]; then
+        if ! (dhclient --help 2>&1 | grep -q -F -- '--timeout' 2> /dev/null); then
+            warn "rd.net.timeout.dhcp has no effect because dhclient does not implement the --timeout option"
+            unset _timeout
+        fi
+    fi
+
     dhclient "$@" \
                  ${_timeout:+--timeout $_timeout} \
                  -q \


### PR DESCRIPTION
dhclient's `--timeout` option is not upstream [1], apparently it's RH-only [2]..., so a pre-check is needed before using it.

[1] https://github.com/isc-projects/dhcp
[2] https://github.com/landgraf/dhcp-fedora/commit/d171ac96

Some tests already take this into account:

https://github.com/openSUSE/dracut/blob/6ee340c32da420ab880f29e699bbb24122ca2fb6/test/TEST-20-NFS/test.sh#L73-L75

https://github.com/openSUSE/dracut/blob/6ee340c32da420ab880f29e699bbb24122ca2fb6/test/TEST-50-MULTINIC/test.sh#L73-L75