### PR TITLE
fix(suse-initrd): always check that MACHINE_ID is not empty (bsc#1201780)

### DIFF
--- a/suse/mkinitrd-suse.sh
+++ b/suse/mkinitrd-suse.sh
@@ -303,9 +303,9 @@ done
 
 if [ -e /etc/machine-id ]; then
     read -r MACHINE_ID < /etc/machine-id
-    if [ -d "$boot_dir/efi/$MACHINE_ID" ]; then
-	error "Looks like systemd-boot is installed. mkinitrd won't work here. Use dracut directly instead."
-	exit 1
+    if [[ $MACHINE_ID ]] && [[ -d "$boot_dir/efi/$MACHINE_ID" ]]; then
+        error "Looks like systemd-boot is installed. mkinitrd won't work here. Use dracut directly instead."
+        exit 1
     fi
 fi
 


### PR DESCRIPTION
On new installations, /etc/machine-id may exist and be empty, and also /boot/efi
may be a mount point, leading to the invalid assumption that systemd-boot is
being used.