### PR TITLE
fix(network-manager): check for nm-initrd-generator in both /usr/{libexec,lib} (bsc#1201975) (055)

### DIFF
--- a/modules.d/40network/module-setup.sh
+++ b/modules.d/40network/module-setup.sh
@@ -19,7 +19,7 @@ depends() {
     if [ -z "$network_handler" ]; then
         if [[ -x $dracutsysrootdir$systemdsystemunitdir/wicked.service ]]; then
             network_handler="network-wicked"
-        elif [[ -x $dracutsysrootdir/usr/libexec/nm-initrd-generator ]]; then
+        elif [[ -x $dracutsysrootdir/usr/libexec/nm-initrd-generator ]] || [[ -x $dracutsysrootdir/usr/lib/nm-initrd-generator ]]; then
             network_handler="network-manager"
         elif [[ -x $dracutsysrootdir$systemdutildir/systemd-networkd ]]; then
             network_handler="systemd-networkd"

--- a/modules.d/80cms/cmsifup.sh
+++ b/modules.d/80cms/cmsifup.sh
@@ -34,7 +34,7 @@ fi
 IFACES="$IFACES $DEVICE"
 echo "$IFACES" >> /tmp/net.ifaces
 
-if [ -x /usr/libexec/nm-initrd-generator ]; then
+if [ -x /usr/libexec/nm-initrd-generator ] || [ -x /usr/lib/nm-initrd-generator ]; then
     type nm_generate_connections > /dev/null 2>&1 || . /lib/nm-lib.sh
     nm_generate_connections
 else


### PR DESCRIPTION
Sice commit 22d6863ef1b2 ("fix(network-manager): cope with distributions not
using `libexec`") nm-initrd-generator can be installed in either /usr/libexec
or /usr/lib. Change other modules to check for the binary in both locations.

(cherry picked from commit 5ee7e249b8cc74461122ccd7efe954b3402c23da)
