### PR TITLE
chore(suse): remove suse-module-tools build requirement

### DIFF
--- a/suse/dracut.spec
+++ b/suse/dracut.spec
@@ -37,7 +37,6 @@ BuildRequires:  asciidoc
 BuildRequires:  bash
 BuildRequires:  docbook-xsl-stylesheets
 BuildRequires:  libxslt
-BuildRequires:  suse-module-tools
 BuildRequires:  pkgconfig(libkmod)
 BuildRequires:  pkgconfig(systemd) >= 219
 BuildRequires:  cargo


### PR DESCRIPTION
This build requirement was added because of the `regenerate_initrd_post` and
`regenerate_initrd_posttrans` macros, but these macros have been provided by the
rpm-config-SUSE package for quite some time:
https://github.com/openSUSE/rpm-config-SUSE/commit/1ea954eb