### PR TITLE
chore(suse): fix 99-debug.conf

### DIFF
--- a/suse/99-debug.conf
+++ b/suse/99-debug.conf
@@ -7,4 +7,4 @@
 # mount|pre-pivot|cleanup]
 # boot parameter or if you are forced to enter the dracut emergency shell.
 
-# add_dracutmodules+=debug
+# add_dracutmodules+=" debug "


### PR DESCRIPTION
The values of `add_dracutmodules` must have leading and trailing whitespace.
