### PR TITLE
chore(suse): update SUSE-specific config

### DIFF
--- a/dracut.conf.d/suse.conf.example
+++ b/dracut.conf.d/suse.conf.example
@@ -3,7 +3,7 @@
 # SUSE by default always builds as small as possible initrd for performance
 # and resource reasons.
 # If you like to build a generic initrd which works on other platforms than
-# on the one dracut/mkinitrd got called comment out below setting(s).
+# on the one dracut got called comment out below setting(s).
 hostonly="yes"
 hostonly_cmdline="yes"
 
@@ -12,13 +12,3 @@ compress="zstd -3 -T0 -q"
 i18n_vars="/etc/sysconfig/language:RC_LANG-LANG,RC_LC_ALL-LC_ALL /etc/sysconfig/console:CONSOLE_UNICODEMAP-FONT_UNIMAP,CONSOLE_FONT-FONT,CONSOLE_SCREENMAP-FONT_MAP /etc/sysconfig/keyboard:KEYTABLE-KEYMAP"
 omit_drivers+=" i2o_scsi "
 
-# Below adds additional tools to the initrd which are not urgently necessary to
-# bring up the system, but help to debug problems.
-# See /usr/lib/dracut/modules.d/95debug/module-setup.sh which additional tools
-# are installed and add more if you need them. This specifically helps if you
-# use:
-# rd.break=[cmdline|pre-udev|pre-trigger|initqueue|pre-mount|
-# mount|pre-pivot|cleanup]
-# boot parameter or if you are forced to enter the dracut emergency shell.
-
-# add_dracutmodules+=debug

--- a/suse/dracut.spec
+++ b/suse/dracut.spec
@@ -158,7 +158,9 @@ install -m 0644 dracut.conf.d/fips.conf.example %{buildroot}%{_sysconfdir}/dracu
 install -m 0644 dracut.conf.d/ima.conf.example %{buildroot}%{_sysconfdir}/dracut.conf.d/40-ima.conf
 # bsc#915218
 %ifarch s390 s390x
-install -m 0644 suse/s390x_persistent_device.conf %{buildroot}%{_sysconfdir}/dracut.conf.d/10-s390x_persistent_device.conf
+install -m 0644 suse/s390x_persistent_policy.conf %{buildroot}%{_sysconfdir}/dracut.conf.d/10-persistent_policy.conf
+%else
+install -m 0644 suse/persistent_policy.conf %{buildroot}%{_sysconfdir}/dracut.conf.d/10-persistent_policy.conf
 %endif
 
 install -D -m 0755 suse/mkinitrd-suse.sh %{buildroot}/%{dracut_sbindir}/mkinitrd
@@ -275,9 +277,7 @@ fi
 %if 0%{?fedora} || 0%{?suse_version} || 0%{?rhel}
 /usr/lib/dracut/dracut.conf.d/01-dist.conf
 %endif
-%ifarch s390 s390x
-%config %{_sysconfdir}/dracut.conf.d/10-s390x_persistent_device.conf
-%endif
+%config %{_sysconfdir}/dracut.conf.d/10-persistent_policy.conf
 
 %{_mandir}/man8/dracut.8*
 %{_mandir}/man1/lsinitrd.1*

--- a/suse/dracut.spec
+++ b/suse/dracut.spec
@@ -137,7 +137,7 @@ Call dracut directly instead.
 %build
 %configure \
   --systemdsystemunitdir=%{_unitdir} \
-  --bashcompletiondir=%{_datarootdir}/bash-completion/completions \
+  --bashcompletiondir=%{_datadir}/bash-completion/completions \
   --libdir=%{_prefix}/lib \
   --enable-dracut-cpio
 %make_build all CFLAGS="%{optflags}" %{?_smp_mflags}
@@ -145,14 +145,34 @@ Call dracut directly instead.
 %install
 %make_install
 
-echo -e "#!/bin/bash\nDRACUT_VERSION=%{version}-%{release}" > %{buildroot}/%{dracutlibdir}/dracut-version.sh
+echo -e "#!/bin/bash\nDRACUT_VERSION=%{version}-%{release}" > %{buildroot}%{dracutlibdir}/dracut-version.sh
+
+# remove architecture specific modules
+%ifnarch ppc ppc64 ppc64le ppc64p7
+rm -rf %{buildroot}%{dracutlibdir}/modules.d/90ppcmac
+%endif
+%ifnarch s390 s390x
+rm -rf %{buildroot}%{dracutlibdir}/modules.d/80cms
+rm -rf %{buildroot}%{dracutlibdir}/modules.d/81cio_ignore
+rm -rf %{buildroot}%{dracutlibdir}/modules.d/91zipl
+rm -rf %{buildroot}%{dracutlibdir}/modules.d/95dasd
+rm -rf %{buildroot}%{dracutlibdir}/modules.d/95dasd_mod
+rm -rf %{buildroot}%{dracutlibdir}/modules.d/95dasd_rules
+rm -rf %{buildroot}%{dracutlibdir}/modules.d/95dcssblk
+rm -rf %{buildroot}%{dracutlibdir}/modules.d/95qeth_rules
+rm -rf %{buildroot}%{dracutlibdir}/modules.d/95zfcp
+rm -rf %{buildroot}%{dracutlibdir}/modules.d/95zfcp_rules
+rm -rf %{buildroot}%{dracutlibdir}/modules.d/95znet
+%else
+rm -rf %{buildroot}%{dracutlibdir}/modules.d/00warpclock
+%endif
 
 mkdir -p %{buildroot}/boot/dracut
 mkdir -p %{buildroot}%{_localstatedir}/lib/dracut/overlay
 mkdir -p %{buildroot}%{_localstatedir}/log
 touch %{buildroot}%{_localstatedir}/log/dracut.log
 
-install -D -m 0644 dracut.conf.d/suse.conf.example %{buildroot}/usr/lib/dracut/dracut.conf.d/01-dist.conf
+install -D -m 0644 dracut.conf.d/suse.conf.example %{buildroot}%{dracutlibdir}/dracut.conf.d/01-dist.conf
 install -m 0644 suse/99-debug.conf %{buildroot}%{_sysconfdir}/dracut.conf.d/99-debug.conf
 install -m 0644 dracut.conf.d/fips.conf.example %{buildroot}%{_sysconfdir}/dracut.conf.d/40-fips.conf
 install -m 0644 dracut.conf.d/ima.conf.example %{buildroot}%{_sysconfdir}/dracut.conf.d/40-ima.conf
@@ -168,15 +188,15 @@ install -D -m 0755 suse/mkinitrd-suse.sh %{buildroot}/%{dracut_sbindir}/mkinitrd
 mv %{buildroot}%{_mandir}/man8/mkinitrd-suse.8 %{buildroot}%{_mandir}/man8/mkinitrd.8
 
 %if 0%{?suse_version}
-rm -f %{buildroot}/%{dracutlibdir}/modules.d/45ifcfg/write-ifcfg.sh
-ln -s %{dracutlibdir}/modules.d/45ifcfg/write-ifcfg-suse.sh %{buildroot}/%{dracutlibdir}/modules.d/45ifcfg/write-ifcfg.sh
+rm -f %{buildroot}%{dracutlibdir}/modules.d/45ifcfg/write-ifcfg.sh
+ln -s %{dracutlibdir}/modules.d/45ifcfg/write-ifcfg-suse.sh %{buildroot}%{dracutlibdir}/modules.d/45ifcfg/write-ifcfg.sh
 %else
-mv %{buildroot}/%{dracutlibdir}/modules.d/45ifcfg/write-ifcfg.sh %{buildroot}/%{dracutlibdir}/modules.d/45ifcfg/write-ifcfg-redhat.sh
-ln -s %{dracutlibdir}/modules.d/45ifcfg/write-ifcfg-redhat.sh %{buildroot}/%{dracutlibdir}/modules.d/45ifcfg/write-ifcfg.sh
+mv %{buildroot}%{dracutlibdir}/modules.d/45ifcfg/write-ifcfg.sh %{buildroot}%{dracutlibdir}/modules.d/45ifcfg/write-ifcfg-redhat.sh
+ln -s %{dracutlibdir}/modules.d/45ifcfg/write-ifcfg-redhat.sh %{buildroot}%{dracutlibdir}/modules.d/45ifcfg/write-ifcfg.sh
 %endif
 
 # create a link to dracut-util to be able to parse kernel command line arguments at generation time
-ln -s %{dracutlibdir}/dracut-util %{buildroot}/%{dracutlibdir}/dracut-getarg
+ln -s %{dracutlibdir}/dracut-util %{buildroot}%{dracutlibdir}/dracut-getarg
 
 %post
 # check whether /var/run has been converted to a symlink
@@ -249,12 +269,15 @@ fi
 %{dracutlibdir}/modules.d/02caps
 %{dracutlibdir}/modules.d/00dash
 %{dracutlibdir}/modules.d/05busybox
+%ifarch ppc ppc64 ppc64le ppc64p7
 %{dracutlibdir}/modules.d/90ppcmac
-
+%endif
+%ifarch s390 s390x
 # RH-specific s390 modules, we take another approach
 %{dracutlibdir}/modules.d/95dasd
 %{dracutlibdir}/modules.d/95zfcp
 %{dracutlibdir}/modules.d/95znet
+%endif
 
 %files mkinitrd-deprecated
 %{dracut_sbindir}/mkinitrd
@@ -267,16 +290,17 @@ fi
 %doc docs/HACKING.md docs/dracut.png docs/dracut.svg
 %{_bindir}/dracut
 %{_bindir}/lsinitrd
-%{_datarootdir}/bash-completion/completions/lsinitrd
+%dir %{_datadir}/bash-completion
+%dir %{_datadir}/bash-completion/completions
+%{_datadir}/bash-completion/completions/dracut
+%{_datadir}/bash-completion/completions/lsinitrd
 %{_datadir}/pkgconfig/dracut.pc
 
 %config(noreplace) %{_sysconfdir}/dracut.conf
 %dir %{_sysconfdir}/dracut.conf.d
-%dir /usr/lib/dracut/dracut.conf.d
+%dir %{dracutlibdir}/dracut.conf.d
+%{dracutlibdir}/dracut.conf.d/01-dist.conf
 %config %{_sysconfdir}/dracut.conf.d/99-debug.conf
-%if 0%{?fedora} || 0%{?suse_version} || 0%{?rhel}
-/usr/lib/dracut/dracut.conf.d/01-dist.conf
-%endif
 %config %{_sysconfdir}/dracut.conf.d/10-persistent_policy.conf
 
 %{_mandir}/man8/dracut.8*
@@ -317,7 +341,9 @@ fi
 %{dracutlibdir}/modules.d/00bash
 %{dracutlibdir}/modules.d/00systemd
 %{dracutlibdir}/modules.d/00systemd-network-management
+%ifnarch s390 s390x
 %{dracutlibdir}/modules.d/00warpclock
+%endif
 %{dracutlibdir}/modules.d/01systemd-ac-power
 %{dracutlibdir}/modules.d/01systemd-ask-password
 %{dracutlibdir}/modules.d/01systemd-coredump
@@ -339,7 +365,6 @@ fi
 %{dracutlibdir}/modules.d/01systemd-tmpfiles
 %{dracutlibdir}/modules.d/01systemd-udevd
 %{dracutlibdir}/modules.d/01systemd-veritysetup
-
 %{dracutlibdir}/modules.d/03modsign
 %{dracutlibdir}/modules.d/03rescue
 %{dracutlibdir}/modules.d/04watchdog
@@ -360,10 +385,14 @@ fi
 %{dracutlibdir}/modules.d/50drm
 %{dracutlibdir}/modules.d/50plymouth
 %{dracutlibdir}/modules.d/62bluetooth
+%ifarch s390 s390x
 %{dracutlibdir}/modules.d/80cms
+%endif
 %{dracutlibdir}/modules.d/80lvmmerge
 %{dracutlibdir}/modules.d/80lvmthinpool-monitor
+%ifarch s390 s390x
 %{dracutlibdir}/modules.d/81cio_ignore
+%endif
 %{dracutlibdir}/modules.d/90btrfs
 %{dracutlibdir}/modules.d/90crypt
 %{dracutlibdir}/modules.d/90dm
@@ -386,11 +415,15 @@ fi
 %{dracutlibdir}/modules.d/91pcsc
 %{dracutlibdir}/modules.d/91pkcs11
 %{dracutlibdir}/modules.d/91tpm2-tss
+%ifarch s390 s390x
 %{dracutlibdir}/modules.d/91zipl
+%endif
 %{dracutlibdir}/modules.d/95cifs
+%ifarch s390 s390x
 %{dracutlibdir}/modules.d/95dasd_mod
 %{dracutlibdir}/modules.d/95dasd_rules
 %{dracutlibdir}/modules.d/95dcssblk
+%endif
 %{dracutlibdir}/modules.d/95debug
 %{dracutlibdir}/modules.d/95fcoe
 %{dracutlibdir}/modules.d/95fcoe-uefi
@@ -400,7 +433,9 @@ fi
 %{dracutlibdir}/modules.d/95nbd
 %{dracutlibdir}/modules.d/95nfs
 %{dracutlibdir}/modules.d/95nvmf
+%ifarch s390 s390x
 %{dracutlibdir}/modules.d/95qeth_rules
+%endif
 %{dracutlibdir}/modules.d/95resume
 %{dracutlibdir}/modules.d/95rootfs-block
 %{dracutlibdir}/modules.d/95ssh-client
@@ -408,7 +443,9 @@ fi
 %{dracutlibdir}/modules.d/95udev-rules
 %{dracutlibdir}/modules.d/95virtfs
 %{dracutlibdir}/modules.d/95virtiofs
+%ifarch s390 s390x
 %{dracutlibdir}/modules.d/95zfcp_rules
+%endif
 %{dracutlibdir}/modules.d/97biosdevname
 %{dracutlibdir}/modules.d/98dracut-systemd
 %{dracutlibdir}/modules.d/98ecryptfs
@@ -430,6 +467,5 @@ fi
 %dir %{_unitdir}/sysinit.target.wants
 %{_unitdir}/*.service
 %{_unitdir}/*/*.service
-%{_datarootdir}/bash-completion/completions/dracut
 
 %changelog

--- a/suse/persistent_policy.conf
+++ b/suse/persistent_policy.conf
@@ -1,0 +1,17 @@
+# When dracut generates the initramfs, it must refer to disks and partitions to
+# be mounted in a persistent manner, to make sure the system will boot
+# correctly. By default, dracut uses /dev/mapper device names.
+# For example, when dracut detects multipath devices, it will use the DM-MP
+# device names such as
+#
+# /dev/mapper/3600a098000aad73f00000a3f5a275dc8-part1
+#
+# This is good if the system always runs in multipath mode. But if the system is
+# started without multipathing, booting with such an initramfs will fail,
+# because the /dev/mapper devices will not exist. The same problem can happen
+# with multipath maps and cloned SAN LUNs.
+#
+# To prevent this from happening, the dracut policy for addressing disks
+# and partitions is changed to use /dev/disk/by-uuid device names on all
+# architectures except s390/s390x, which must be by-path (bsc#915218).
+persistent_policy="by-uuid"

--- a/suse/s390x_persistent_policy.conf
+++ b/suse/s390x_persistent_policy.conf
@@ -7,4 +7,4 @@
 # they are cleared after logoff/logon and the UUID will likely
 # change after reinitialization, these will not be found with
 # the default by-uuid policy.
-persistent_policy=by-path
+persistent_policy="by-path"


### PR DESCRIPTION
- Remove reference to `mkinitrd`.
- Remove explanatory code that is currently shipped in [suse/99-debug.conf](https://github.com/openSUSE/dracut/blob/SUSE/057/suse/99-debug.conf).
- Change default persistent policy to `by-uuid` (except for s390x, bsc#915218). Reasoning:
  - https://www.suse.com/support/kb/doc/?id=000019656
  - https://susedoc.github.io/doc-sle/SLE15SP4/html/SLES-storage/cha-multipath.html#sec-multipath-initrd-persistent
- Fix spec file:
  - Do not install modules incompatible with the system architecture.
  - Fix "directories not owned by a package" caused by bash-completion directories not owned by dracut.