### PR TITLE
fix(i18n): do not fail if FONT in /etc/vconsole.conf has the file extension (bsc#1203267)

### DIFF
--- a/modules.d/10i18n/module-setup.sh
+++ b/modules.d/10i18n/module-setup.sh
@@ -222,8 +222,12 @@ install() {
         inst_opt_decompress "${kbddir}"/consolefonts/"${DEFAULT_FONT}".*
 
         if [[ ${FONT} ]] && [[ ${FONT} != "${DEFAULT_FONT}" ]]; then
-            FONT=${FONT%.psf*}
-            inst_opt_decompress "${kbddir}"/consolefonts/"${FONT}".*
+            if [[ -f "${kbddir}"/consolefonts/"${FONT}" ]]; then
+                inst_opt_decompress "${kbddir}"/consolefonts/"${FONT}"
+            else
+                FONT=${FONT%.psf*}
+                inst_opt_decompress "${kbddir}"/consolefonts/"${FONT}".*
+            fi
         fi
 
         if [[ ${FONT_MAP} ]]; then


### PR DESCRIPTION
If the `FONT` option defined in `/etc/vconsole.conf` refers to a file with its extension, not just the file name, dracut should not fail and install it. The `systemd-vconsole-setup` service ends up calling `setfont`, which supports both file names and files with extensions.

(cherry picked from commit e1de5bd2d711df2c6814a3c3ab8472cdb4de9101)
