### PR TITLE
chore(suse): change default persistent policy (SLE15-SP5:GA)

### DIFF
--- a/suse/dracut.spec
+++ b/suse/dracut.spec
@@ -161,7 +161,9 @@ install -m 0644 dracut.conf.d/fips.conf.example %{buildroot}%{_sysconfdir}/dracu
 install -m 0644 dracut.conf.d/ima.conf.example %{buildroot}%{_sysconfdir}/dracut.conf.d/40-ima.conf
 # bsc#915218
 %ifarch s390 s390x
-install -m 0644 suse/s390x_persistent_device.conf %{buildroot}%{_sysconfdir}/dracut.conf.d/10-s390x_persistent_device.conf
+install -m 0644 suse/s390x_persistent_policy.conf %{buildroot}%{_sysconfdir}/dracut.conf.d/10-persistent_policy.conf
+%else
+install -m 0644 suse/persistent_policy.conf %{buildroot}%{_sysconfdir}/dracut.conf.d/10-persistent_policy.conf
 %endif
 
 install -D -m 0755 suse/mkinitrd-suse.sh %{buildroot}/%{dracut_sbindir}/mkinitrd
@@ -279,9 +281,7 @@ fi
 %if 0%{?fedora} || 0%{?suse_version} || 0%{?rhel}
 /usr/lib/dracut/dracut.conf.d/01-dist.conf
 %endif
-%ifarch s390 s390x
-%config %{_sysconfdir}/dracut.conf.d/10-s390x_persistent_device.conf
-%endif
+%config %{_sysconfdir}/dracut.conf.d/10-persistent_policy.conf
 
 %{_mandir}/man8/dracut.8*
 %{_mandir}/man1/lsinitrd.1*

--- a/suse/persistent_policy.conf
+++ b/suse/persistent_policy.conf
@@ -1,0 +1,17 @@
+# When dracut generates the initramfs, it must refer to disks and partitions to
+# be mounted in a persistent manner, to make sure the system will boot
+# correctly. By default, dracut uses /dev/mapper device names.
+# For example, when dracut detects multipath devices, it will use the DM-MP
+# device names such as
+#
+# /dev/mapper/3600a098000aad73f00000a3f5a275dc8-part1
+#
+# This is good if the system always runs in multipath mode. But if the system is
+# started without multipathing, booting with such an initramfs will fail,
+# because the /dev/mapper devices will not exist. The same problem can happen
+# with multipath maps and cloned SAN LUNs.
+#
+# To prevent this from happening, the dracut policy for addressing disks
+# and partitions is changed to use /dev/disk/by-uuid device names on all
+# architectures except s390/s390x, which must be by-path (bsc#915218).
+persistent_policy="by-uuid"

--- a/suse/s390x_persistent_policy.conf
+++ b/suse/s390x_persistent_policy.conf
@@ -7,4 +7,4 @@
 # they are cleared after logoff/logon and the UUID will likely
 # change after reinitialization, these will not be found with
 # the default by-uuid policy.
-persistent_policy=by-path
+persistent_policy="by-path"


### PR DESCRIPTION
When dracut generates the initramfs, it must refer to disks and partitions to be mounted in a persistent manner, to make sure the system will boot correctly. By default, dracut uses `/dev/mapper` device names. For example, when dracut detects multipath devices, it will use the DM-MP device names such as
```
/dev/mapper/3600a098000aad73f00000a3f5a275dc8-part1
```
This is good if the system always runs in multipath mode. But if the system is started without multipathing, booting with such an initramfs will fail, because the `/dev/mapper` devices will not exist. The same problem can happen with multipath maps and cloned SAN LUNs.

To prevent this from happening, the dracut policy for addressing disks and partitions is changed to use `/dev/disk/by-uuid` device names on all architectures except s390/s390x, which must be `by-path` (bsc#915218).

Refs:
- https://www.suse.com/support/kb/doc/?id=000019656
- https://susedoc.github.io/doc-sle/SLE15SP4/html/SLES-storage/cha-multipath.html#sec-multipath-initrd-persistent

jsc#PED-1885
