### PR TITLE
fix(network-legacy): avoid misleading warning when detecting duplicate address (bsc#1201235)

### DIFF
--- a/modules.d/35network-legacy/dhclient-script.sh
+++ b/modules.d/35network-legacy/dhclient-script.sh
@@ -193,7 +193,8 @@ case $reason in
                     exit 1
                 fi
             else
-                if ! wicked arp verify --quiet --count 2 --interval 1000 "$netif" "$new_ip_address"; then
+                wicked arp verify --quiet --count 2 --interval 1000 "$netif" "$new_ip_address"
+                if [ $? -eq 4 ]; then
                     warn "Duplicate address detected for $new_ip_address while doing dhcp. retrying"
                     exit 1
                 fi

--- a/modules.d/35network-legacy/ifup.sh
+++ b/modules.d/35network-legacy/ifup.sh
@@ -364,7 +364,8 @@ do_static() {
                     return 1
                 fi
             else
-                if ! wicked arp verify --quiet --count 2 --interval 1000 "$netif" "$ip"; then
+                wicked arp verify --quiet --count 2 --interval 1000 "$netif" "$ip"
+                if [ $? -eq 4 ]; then
                     warn "Duplicate address detected for $ip for interface $netif."
                     return 1
                 fi


### PR DESCRIPTION
Check only the specific code (4) returned by wicked when a duplicate address is detected.