### PR TITLE
fix(drm): consider also drm_dev_register when looking for gpu driver (bsc#1195618) (049)

### DIFF
--- a/modules.d/50drm/module-setup.sh
+++ b/modules.d/50drm/module-setup.sh
@@ -33,7 +33,7 @@ installkernel() {
     if [[ $hostonly ]]; then
         for i in /sys/bus/{pci/devices,virtio/devices,soc/devices/soc?}/*/modalias; do
             [[ -e $i ]] || continue
-            if hostonly="" dracut_instmods --silent -s "drm_crtc_init" -S "iw_handler_get_spy" $(<$i); then
+            if hostonly="" dracut_instmods --silent -s "drm_crtc_init|drm_dev_register" -S "iw_handler_get_spy" $(<$i); then
                 if strstr "$(modinfo -F filename $(<$i) 2>/dev/null)" radeon.ko; then
                     hostonly='' instmods amdkfd
                 fi

--- a/modules.d/50drm/module-setup.sh
+++ b/modules.d/50drm/module-setup.sh
@@ -40,6 +40,6 @@ installkernel() {
             fi
         done
     else
-        dracut_instmods -o -s "drm_crtc_init" "=drivers/gpu/drm" "=drivers/staging"
+        dracut_instmods -o -s "drm_crtc_init|drm_dev_register" "=drivers/gpu/drm" "=drivers/staging"
     fi
 }


### PR DESCRIPTION
Fix graphics startup failure looking also for the `drm_dev_register` symbol.