### PR TITLE
fix(network-manager): always install the library plugins directory (bsc#1202014) (055)

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -591,6 +591,21 @@ inst_any() {
     return 1
 }
 
+# inst_libdir_dir <dir> [<dir>...]
+# Install a <dir> located on a lib directory to the initramfs image
+inst_libdir_dir() {
+    local -a _dirs
+    for _dir in $libdirs; do
+        for _i in "$@"; do
+            for _d in "$dracutsysrootdir$_dir"/$_i; do
+                [[ -d $_d ]] && _dirs+=("${_d#"$dracutsysrootdir"}")
+            done
+        done
+    done
+    for _dir in "${_dirs[@]}"; do
+        inst_dir "$_dir"
+    done
+}
 
 # inst_libdir_file [-n <pattern>] <file> [<file>...]
 # Install a <file> located on a lib directory to the initramfs image

--- a/modules.d/35network-manager/module-setup.sh
+++ b/modules.d/35network-manager/module-setup.sh
@@ -61,6 +61,7 @@ install() {
     inst_hook initqueue/settled 99 "$moddir/nm-run.sh"
 
     inst_rules 85-nm-unmanaged.rules
+    inst_libdir_dir "NetworkManager/$_nm_version"
     inst_libdir_file "NetworkManager/$_nm_version/libnm-device-plugin-team.so"
     inst_simple "$moddir/nm-lib.sh" "/lib/nm-lib.sh"
 


### PR DESCRIPTION
The library plugins directory is automatically added to the initrd if either `libnm-device-plugin-team.so` or `libnm-settings-plugin-ifcfg-rh.so` are present on the system, but both are optional libraries, and if it does not exist, the NetworkManager issues a warning.

(cherry picked from commit 429f9de1c767c816301097a42cec762dc82d67da)