### PR TITLE
fix(nfs): chown using rpc default group (bsc#1204929) (055)

### DIFF
--- a/modules.d/95nfs/nfs-start-rpc.sh
+++ b/modules.d/95nfs/nfs-start-rpc.sh
@@ -9,7 +9,7 @@ if modprobe sunrpc || strstr "$(cat /proc/filesystems)" rpc_pipefs; then
     command -v portmap > /dev/null && [ -z "$(pidof portmap)" ] && portmap
     if command -v rpcbind > /dev/null && [ -z "$(pidof rpcbind)" ]; then
         mkdir -p /run/rpcbind
-        chown rpc:rpc /run/rpcbind
+        chown rpc: /run/rpcbind
         rpcbind
     fi
 

--- a/modules.d/95nfs/parse-nfsroot.sh
+++ b/modules.d/95nfs/parse-nfsroot.sh
@@ -124,5 +124,5 @@ root="$fstype"
 echo '[ -e $NEWROOT/proc ]' > "$hookdir"/initqueue/finished/nfsroot.sh
 
 mkdir -p /var/lib/rpcbind
-chown rpc:rpc /var/lib/rpcbind
+chown rpc: /var/lib/rpcbind
 chmod 770 /var/lib/rpcbind


### PR DESCRIPTION
This is necessary to handle old versions of `rpcbind` that do not create the "rpc" group.