### PR TITLE
fix(dracut.sh): improve detection of installed kernel versions (bsc#1205175)

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -971,12 +971,14 @@ if [[ $regenerate_all == "yes" ]]; then
     if [[ $parallel != "yes" ]]; then
         for i in *; do
             [[ -f $i/modules.dep ]] || [[ -f $i/modules.dep.bin ]] || continue
+            [[ -d $i/kernel ]] || continue
             "$dracut_cmd" --kver="$i" "${dracut_args[@]}"
             ((ret += $?))
         done
     else
         for i in *; do
             [[ -f $i/modules.dep ]] || [[ -f $i/modules.dep.bin ]] || continue
+            [[ -d $i/kernel ]] || continue
             "$dracut_cmd" --kver="$i" "${dracut_args[@]}" &
         done
         while true; do


### PR DESCRIPTION
SUSE-specific patch needed to improve the detection of kernel versions installed on the system when running dracut with the `--regenerate-all` option.