### PR TITLE
fix(dracut.sh): improve detection of installed kernel versions (bsc#1205175) (055)

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -865,6 +865,7 @@ if [[ $regenerate_all == "yes" ]]; then
     cd "$dracutsysrootdir"/lib/modules || exit 1
     for i in *; do
         [[ -f $i/modules.dep ]] || [[ -f $i/modules.dep.bin ]] || continue
+        [[ -d $i/kernel ]] || continue
         "$dracut_cmd" --kver="$i" "${dracut_args[@]}"
         ((ret += $?))
     done


### PR DESCRIPTION
SUSE-specific patch needed to improve the detection of kernel versions installed on the system when running dracut with the `--regenerate-all` option.