### PR TITLE
fix(dracut-systemd): run systemctl daemon-reload after remove_hostonly_files

### DIFF
--- a/modules.d/98dracut-systemd/dracut-cmdline.sh
+++ b/modules.d/98dracut-systemd/dracut-cmdline.sh
@@ -11,6 +11,7 @@ type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
 if ! getargbool 1 'rd.hostonly'; then
     [ -f /etc/cmdline.d/99-cmdline-ask.conf ] && mv /etc/cmdline.d/99-cmdline-ask.conf /tmp/99-cmdline-ask.conf
     remove_hostonly_files
+    systemctl --no-block daemon-reload
     [ -f /tmp/99-cmdline-ask.conf ] && mv /tmp/99-cmdline-ask.conf /etc/cmdline.d/99-cmdline-ask.conf
 fi
 


### PR DESCRIPTION
Dependencies to systemd .device unit files are marked as "hostonly" in the special file hostonly-files. These .device unit files can be removed using the `rd.hostonly=0` command line parameter. But, since systemd v252 (https://github.com/systemd/systemd/pull/24054), the initrd-parse-etc.service service does not run `systemctl daemon-reload`, so systemd keeps waiting for these .device units to show up.
This means that if a hostonly device is not available for any reason at boot time, using `rd.hostonly=0` has no effect and the system will not boot.

(cherry picked from commit e1058b07ea2acb1bdb2d52f778639e093b1ed8a6)