### PR TITLE
FIPS fixes

### DIFF
--- a/modules.d/01fips/fips.sh
+++ b/modules.d/01fips/fips.sh
@@ -1,16 +1,20 @@
 #!/bin/bash
 
 # find fipscheck, prefer kernel-based version
-fipscheck()
-{
-    FIPSCHECK=/usr/lib64/libkcapi/fipscheck
-    if [ ! -f $FIPSCHECK ]; then
-        FIPSCHECK=/usr/lib/libkcapi/fipscheck
+fipscheck() {
+    local _fipscheck
+
+    if [ -f "/usr/lib64/libkcapi/fipscheck" ]; then
+        _fipscheck="/usr/lib64/libkcapi/fipscheck"
+    elif [ -f "/usr/lib/libkcapi/fipscheck" ]; then
+        _fipscheck="/usr/lib/libkcapi/fipscheck"
+    elif [ -f "/usr/libexec/libkcapi/fipscheck" ]; then
+        _fipscheck="/usr/libexec/libkcapi/fipscheck"
+    elif [ -f "/usr/bin/fipscheck" ]; then
+        _fipscheck="/usr/bin/fipscheck"
     fi
-    if [ ! -f $FIPSCHECK ]; then
-        FIPSCHECK=/usr/bin/fipscheck
-    fi
-    echo $FIPSCHECK
+
+    echo $_fipscheck
 }
 
 type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh

--- a/modules.d/01fips/module-setup.sh
+++ b/modules.d/01fips/module-setup.sh
@@ -72,7 +72,7 @@ install() {
     inst_hook pre-udev 01 "$moddir/fips-load-crypto.sh"
     inst_script "$moddir/fips.sh" /sbin/fips.sh
 
-    inst_multiple rmmod insmod mount uname umount
+    inst_multiple rmmod insmod mount uname umount sed
     inst_multiple -o sha512hmac \
                      fipscheck \
                      /usr/lib64/libkcapi/fipscheck \

--- a/modules.d/01fips/module-setup.sh
+++ b/modules.d/01fips/module-setup.sh
@@ -2,6 +2,13 @@
 
 # called by dracut
 check() {
+    require_any_binary \
+         /usr/lib64/libkcapi/fipscheck \
+         /usr/lib/libkcapi/fipscheck \
+         /usr/libexec/libkcapi/fipscheck \
+         fipscheck \
+        || return 1
+
     return 255
 }
 
@@ -74,9 +81,10 @@ install() {
 
     inst_multiple rmmod insmod mount uname umount sed
     inst_multiple -o sha512hmac \
-                     fipscheck \
                      /usr/lib64/libkcapi/fipscheck \
-                     /usr/lib/libkcapi/fipscheck
+                     /usr/lib/libkcapi/fipscheck \
+                     /usr/libexec/libkcapi/fipscheck \
+                     fipscheck
 
     inst_simple /etc/system-fips
     [ -c "${initdir}"/dev/random ] || mknod "${initdir}"/dev/random c 1 8 \


### PR DESCRIPTION
- fix(fips): install required `sed` binary
Used in the `fips.sh` script.

- fix(fips): check for `fipscheck` in libexec
In Tumbleweed, `libkcapi-tools` installs `fipscheck` in /usr/libexec/libkcapi.
Also, implemented the check method so the installation fails if no `fipscheck`
binary is found, to avoid what was happening in TW (the fips module is
installed, but  `fipscheck` was not included in the initrd).

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
