### PR TITLE
feat(kernel-modules): exclude USB drivers in strict hostonly mode (bs…

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -45,13 +45,14 @@ installkernel() {
 
     if [[ -z $drivers ]]; then
         hostonly='' instmods \
-            hid_generic unix \
+            hid_generic unix
+
+        hostonly=$(optional_hostonly) instmods \
             ehci-hcd ehci-pci ehci-platform \
             ohci-hcd ohci-pci \
             uhci-hcd \
-            xhci-hcd xhci-pci xhci-plat-hcd
-
-        hostonly=$(optional_hostonly) instmods \
+            usbhid \
+            xhci-hcd xhci-pci xhci-plat-hcd \
             "=drivers/hid" \
             "=drivers/tty/serial" \
             "=drivers/input/serio" \
@@ -64,7 +65,7 @@ installkernel() {
 
         instmods \
             yenta_socket \
-            atkbd i8042 usbhid firewire-ohci pcmcia hv-vmbus \
+            atkbd i8042 firewire-ohci pcmcia hv-vmbus \
             virtio virtio_ring virtio_pci pci_hyperv \
             "=drivers/pcmcia"
 


### PR DESCRIPTION
…c#1186056)

Provide a way to avoid installing all USB drivers in some use cases where they are not needed, i.e., machines without a USB bus.

(cherry picked from commit 7debf540ca69d9171cb86b4752c882bac997c26e)

This pull request changes...

## Changes

## Checklist
- [x ] I have tested it locally
 * only on x86_64
 * ppc64 test VMs, where the issue was seen are not available
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
