### PR TITLE
revert(fips): check for fipscheck in libexec (bsc#1206431)

### DIFF
--- a/modules.d/01fips/fips.sh
+++ b/modules.d/01fips/fips.sh
@@ -1,20 +1,16 @@
 #!/bin/bash
 
 # find fipscheck, prefer kernel-based version
-fipscheck() {
-    local _fipscheck
-
-    if [ -f "/usr/lib64/libkcapi/fipscheck" ]; then
-        _fipscheck="/usr/lib64/libkcapi/fipscheck"
-    elif [ -f "/usr/lib/libkcapi/fipscheck" ]; then
-        _fipscheck="/usr/lib/libkcapi/fipscheck"
-    elif [ -f "/usr/libexec/libkcapi/fipscheck" ]; then
-        _fipscheck="/usr/libexec/libkcapi/fipscheck"
-    elif [ -f "/usr/bin/fipscheck" ]; then
-        _fipscheck="/usr/bin/fipscheck"
+fipscheck()
+{
+    FIPSCHECK=/usr/lib64/libkcapi/fipscheck
+    if [ ! -f $FIPSCHECK ]; then
+        FIPSCHECK=/usr/lib/libkcapi/fipscheck
     fi
-
-    echo $_fipscheck
+    if [ ! -f $FIPSCHECK ]; then
+        FIPSCHECK=/usr/bin/fipscheck
+    fi
+    echo $FIPSCHECK
 }
 
 type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh

--- a/modules.d/01fips/module-setup.sh
+++ b/modules.d/01fips/module-setup.sh
@@ -2,13 +2,6 @@
 
 # called by dracut
 check() {
-    require_any_binary \
-         /usr/lib64/libkcapi/fipscheck \
-         /usr/lib/libkcapi/fipscheck \
-         /usr/libexec/libkcapi/fipscheck \
-         fipscheck \
-        || return 1
-
     return 255
 }
 
@@ -81,10 +74,9 @@ install() {
 
     inst_multiple rmmod insmod mount uname umount sed
     inst_multiple -o sha512hmac \
+                     fipscheck \
                      /usr/lib64/libkcapi/fipscheck \
-                     /usr/lib/libkcapi/fipscheck \
-                     /usr/libexec/libkcapi/fipscheck \
-                     fipscheck
+                     /usr/lib/libkcapi/fipscheck
 
     inst_simple /etc/system-fips
     [ -c "${initdir}"/dev/random ] || mknod "${initdir}"/dev/random c 1 8 \


### PR DESCRIPTION
This reverts commit 62d2afa663acedc6fe4a01f1a937783187cc4450.

libkcapi/fipscheck (SLE default) is failing in TW, so keep things as they were.
