### PR TITLE
fix(dracut.spec): require libopenssl1_1-hmac for dracut-fips (bsc#1206439) (055)

### DIFF
--- a/suse/dracut.spec
+++ b/suse/dracut.spec
@@ -83,6 +83,7 @@ Requires:       %{name} = %{version}-%{release}
 Requires:       libcryptsetup12-hmac
 Requires:       libgcrypt20-hmac
 Requires:       libkcapi-tools
+Requires:       libopenssl1_1-hmac
 
 %description fips
 This package requires everything which is needed to build an


### PR DESCRIPTION
systemd is linked against OpenSSL.