### PR TITLE
revert(multipath): install multipathd.socket (bsc#1207524)

### DIFF
--- a/modules.d/90multipath/module-setup.sh
+++ b/modules.d/90multipath/module-setup.sh
@@ -147,7 +147,6 @@ install() {
             inst_simple "${moddir}/multipathd-configure.service" "${systemdsystemunitdir}/multipathd-configure.service"
             $SYSTEMCTL -q --root "$initdir" enable multipathd-configure.service
         fi
-        inst_simple "${systemdsystemunitdir}/multipathd.socket"
         inst_simple "${moddir}/multipathd.service" "${systemdsystemunitdir}/multipathd.service"
         $SYSTEMCTL -q --root "$initdir" enable multipathd.service
     else


### PR DESCRIPTION
This reverts commit 02e646fc7ec91e1fbaa0f2097f35781ae41da937.

It is causing a boot hang: https://openqa.opensuse.org/tests/3067028#step/first_boot/3