### PR TITLE
feat(lvm): always include all drivers that LVM can use (bsc#1206195) (SLE15-SP5:GA)

### DIFF
--- a/modules.d/90lvm/module-setup.sh
+++ b/modules.d/90lvm/module-setup.sh
@@ -43,7 +43,7 @@ cmdline() {
 }
 
 installkernel() {
-    hostonly='' instmods dm-snapshot
+    hostonly='' dracut_instmods -o -P ".*/(bcache/|md-cluster).*" "=drivers/md"
 }
 
 # called by dracut


### PR DESCRIPTION
This patch adds all the kernel modules that might be needed by LVM, to avoid having to rebuild the initrd in hostonly mode after a dynamic change that requires new drivers to boot.

For example, LVM allows to dynamically convert a linear logical volume to a RAID-1 type (`lvconvert --type raid1 vg/lv`), which, in hostonly mode, will require the user to manually rebuild the initrd again to include the new RAID drivers in use, otherwise the system will fail to boot.

(cherry picked from commit a109c6123ffa8506379b73a4b1aeee4d0b67866d)
