### PR TITLE
dracut-install: ignore bogus preload libs (bsc#1208690) (049)

### DIFF
--- a/install/dracut-install.c
+++ b/install/dracut-install.c
@@ -482,6 +482,9 @@ static int resolve_deps(const char *src)
                 if (strstr(buf, "cannot read header"))
                         break;
 
+                if (strstr(buf, "cannot be preloaded"))
+                        break;
+
                 if (strstr(buf, destrootdir))
                         break;
 


### PR DESCRIPTION
If there are any nonexistent libraries listed in /etc/ld.so.preload, ldd prints error messages like:

ERROR: ld.so: object '/usr/lib64/libfoo.so.1' from /etc/ld.so.preload cannot be preloaded (cannot open shared object file): ignored.

This causes resolve_deps() to return error, which leads to symlinks (like usr/bin/awk) not being copied into the initrd.

(cherry picked from commit 4916dfc2b94dca0e84eb7dc58a9266d02c416b4a)
