### PR TITLE
add libkcapi fipscheck also with the libexec location (bsc#1198065 bs…

### DIFF
--- a/modules.d/01fips/fips.sh
+++ b/modules.d/01fips/fips.sh
@@ -3,7 +3,10 @@
 # find fipscheck, prefer kernel-based version
 fipscheck()
 {
-    FIPSCHECK=/usr/lib64/libkcapi/fipscheck
+    FIPSCHECK=/usr/libexec/libkcapi/fipscheck
+    if [ ! -f $FIPSCHECK ]; then
+        FIPSCHECK=/usr/lib64/libkcapi/fipscheck
+    fi
     if [ ! -f $FIPSCHECK ]; then
         FIPSCHECK=/usr/lib/libkcapi/fipscheck
     fi

--- a/modules.d/01fips/module-setup.sh
+++ b/modules.d/01fips/module-setup.sh
@@ -75,6 +75,7 @@ install() {
     inst_multiple rmmod insmod mount uname umount sed
     inst_multiple -o sha512hmac \
                      fipscheck \
+                     /usr/libexec/libkcapi/fipscheck \
                      /usr/lib64/libkcapi/fipscheck \
                      /usr/lib/libkcapi/fipscheck
 


### PR DESCRIPTION
…c#1207892)

This pull request adds a new location of the libkcapi based fipscheck binary in /usr/libexec/libkcapi/fipscheck.

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes (bsc#1198065 bsc#1207892)