### PR TITLE
fix(dracut.sh): omission is an addition to other omissions in conf files

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -717,6 +717,7 @@ unset NPATH
 
 # these options add to the stuff in the config file
 (( ${#add_dracutmodules_l[@]} )) && add_dracutmodules+=" ${add_dracutmodules_l[@]} "
+(( ${#omit_dracutmodules_l[@]})) && omit_dracutmodules+=" ${omit_dracutmodules_l[*]} "
 (( ${#force_add_dracutmodules_l[@]} )) && force_add_dracutmodules+=" ${force_add_dracutmodules_l[@]} "
 (( ${#fscks_l[@]} )) && fscks+=" ${fscks_l[@]} "
 (( ${#add_fstab_l[@]} )) && add_fstab+=" ${add_fstab_l[@]} "
@@ -726,7 +727,6 @@ unset NPATH
 
 # these options override the stuff in the config file
 (( ${#dracutmodules_l[@]} )) && dracutmodules="${dracutmodules_l[@]}"
-(( ${#omit_dracutmodules_l[@]} )) && omit_dracutmodules="${omit_dracutmodules_l[@]}"
 (( ${#filesystems_l[@]} )) && filesystems="${filesystems_l[@]}"
 (( ${#fw_dir_l[@]} )) && fw_dir="${fw_dir_l[@]}"
 (( ${#libdirs_l[@]} ))&& libdirs="${libdirs_l[@]}"


### PR DESCRIPTION
When omitting a module from the command line via -o or --omit it's expected that it behaves in the same manner as adding a module from the command line as in it does not overwrite existing omissions of other modules in configuration file(s).

(cherry picked from commit 96c313333d1a4f5e2c524a3a11c5b3aab24afc20)

This pull request changes...

## Changes

## Checklist
- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #

bsc#1208929