### PR TITLE
fix(fips): `fips=1` and separate `/boot` break s390x (bsc#1204478) (055)

### DIFF
--- a/modules.d/01fips/fips-boot.sh
+++ b/modules.d/01fips/fips-boot.sh
@@ -8,7 +8,9 @@ elif [ -z "$fipsmode" ]; then
     die "FIPS mode have to be enabled by 'fips=1' not just 'fips'"
 elif getarg boot= > /dev/null; then
     . /sbin/fips.sh
+    fips_info "fips-boot: start"
     if mount_boot; then
         do_fips || die "FIPS integrity test failed"
     fi
+    fips_info "fips-boot: done!"
 fi

--- a/modules.d/01fips/fips-load-crypto.sh
+++ b/modules.d/01fips/fips-load-crypto.sh
@@ -8,5 +8,7 @@ elif [ -z "$fipsmode" ]; then
     die "FIPS mode have to be enabled by 'fips=1' not just 'fips'"
 else
     . /sbin/fips.sh
+    fips_info "fips-load-crypto: start"
     fips_load_crypto || die "FIPS integrity test failed"
+    fips_info "fips-load-crypto: done!"
 fi

--- a/modules.d/01fips/fips-noboot.sh
+++ b/modules.d/01fips/fips-noboot.sh
@@ -8,6 +8,8 @@ elif [ -z "$fipsmode" ]; then
     die "FIPS mode have to be enabled by 'fips=1' not just 'fips'"
 elif ! [ -f /tmp/fipsdone ]; then
     . /sbin/fips.sh
+    fips_info "fips-noboot: start"
     mount_boot
     do_fips || die "FIPS integrity test failed"
+    fips_info "fips-noboot: done!"
 fi

--- a/modules.d/01fips/fips.sh
+++ b/modules.d/01fips/fips.sh
@@ -60,7 +60,7 @@ mount_boot() {
         mkdir -p /boot
         fips_info "Mounting $boot as /boot"
         mount -oro "$boot" /boot || return 1
-    elif [ -d "$NEWROOT/boot" ]; then
+    elif ! ismounted /boot && [ -d "$NEWROOT/boot" ]; then
         # shellcheck disable=SC2114
         rm -fr -- /boot
         ln -sf "$NEWROOT/boot" /boot

--- a/modules.d/01fips/fips.sh
+++ b/modules.d/01fips/fips.sh
@@ -31,6 +31,15 @@ mount_boot() {
     boot=$(getarg boot=)
 
     if [ -n "$boot" ]; then
+        if [ -d /boot ] && ismounted /boot; then
+            boot_dev=
+            if command -v findmnt > /dev/null; then
+                boot_dev=$(findmnt -n -o SOURCE /boot)
+            fi
+            fips_info "Ignoring 'boot=$boot' as /boot is already mounted ${boot_dev:+"from '$boot_dev'"}"
+            return 0
+        fi
+
         case "$boot" in
             LABEL=* | UUID=* | PARTUUID=* | PARTLABEL=*)
                 boot="$(label_uuid_to_dev "$boot")"
@@ -60,10 +69,13 @@ mount_boot() {
         mkdir -p /boot
         fips_info "Mounting $boot as /boot"
         mount -oro "$boot" /boot || return 1
+        FIPS_MOUNTED_BOOT=1
     elif ! ismounted /boot && [ -d "$NEWROOT/boot" ]; then
         # shellcheck disable=SC2114
         rm -fr -- /boot
         ln -sf "$NEWROOT/boot" /boot
+    else
+        die "You have to specify boot=<boot device> as a boot option for fips=1"
     fi
 }
 
@@ -228,7 +240,12 @@ do_fips() {
 
     : > /tmp/fipsdone
 
-    umount /boot > /dev/null 2>&1
+    if [ "$FIPS_MOUNTED_BOOT" = 1 ]; then
+        fips_info "Unmounting /boot"
+        umount /boot > /dev/null 2>&1
+    else
+        fips_info "Not unmounting /boot"
+    fi
 
     return 0
 }

--- a/modules.d/01fips/module-setup.sh
+++ b/modules.d/01fips/module-setup.sh
@@ -66,7 +66,7 @@ installkernel() {
 
 # called by dracut
 install() {
-    inst_hook pre-mount 01 "$moddir/fips-boot.sh"
+    inst_hook pre-pivot 00 "$moddir/fips-boot.sh"
     inst_hook pre-pivot 01 "$moddir/fips-noboot.sh"
     inst_hook pre-udev 01 "$moddir/fips-load-crypto.sh"
     inst_script "$moddir/fips.sh" /sbin/fips.sh


### PR DESCRIPTION
This is caused by the `fips` dracut module blindly unmounting `/boot`, regardless whether it was mounted before, which consequently breaks `grub2` later in `cleanup` of the "zipl-booted" initial initrd.
