### PR TITLE
Fixes for NVMeoF/TCP boot bugs

### DIFF
--- a/modules.d/95nvmf/module-setup.sh
+++ b/modules.d/95nvmf/module-setup.sh
@@ -136,6 +136,7 @@ install() {
     inst_multiple ip sed
 
     inst_script "${moddir}/nvmf-autoconnect.sh" /sbin/nvmf-autoconnect.sh
+    inst_script "${moddir}/nbftroot.sh" /sbin/nbftroot
 
     inst_multiple nvme jq
     inst_hook cmdline 92 "$moddir/parse-nvmf-boot-connections.sh"

--- a/modules.d/95nvmf/nbftroot.sh
+++ b/modules.d/95nvmf/nbftroot.sh
@@ -1,0 +1,6 @@
+#! /bin/sh
+# This script is called from /sbin/netroot
+
+echo "$0 $@" >&2
+/sbin/nvmf-autoconnect.sh online
+exit 0

--- a/modules.d/95nvmf/parse-nvmf-boot-connections.sh
+++ b/modules.d/95nvmf/parse-nvmf-boot-connections.sh
@@ -183,7 +183,7 @@ nbft_parse_hfi() {
             "$(nbft_run_jq -r .primary_dns_ipaddr "$hfi_json")")
         dns2=$(nbft_check_empty_address \
             "$(nbft_run_jq -r .secondary_dns_ipaddr "$hfi_json")")
-        hostname=$(nbft_run_jq -r .host_name "$hfi_json") || hostname=
+        hostname=$(nbft_run_jq -r .host_name "$hfi_json" 2> /dev/null) || hostname=
 
         echo "ip=$ipaddr::$gateway:$prefix:$hostname:$iface${vlan:+.$vlan}:none${dns1:+:$dns1}${dns2:+:$dns2}"
     fi

--- a/modules.d/95nvmf/parse-nvmf-boot-connections.sh
+++ b/modules.d/95nvmf/parse-nvmf-boot-connections.sh
@@ -292,6 +292,22 @@ parse_nvmf_discover() {
     return 0
 }
 
+nvmf_timeout_udev_rule() {
+    local timeout
+
+    timeout=$(getarg rd.timeout)
+    case $timeout in
+        0 | "")
+            timeout=-1
+            ;;
+    esac
+    mkdir -p /etc/udev/rules.d
+    printf -- 'ACTION=="add|change", SUBSYSTEM=="nvme", KERNEL=="nvme*", ATTR{ctrl_loss_tmo}="%d"\n' "$timeout" \
+        > /etc/udev/rules.d/90-nvmf-timeout.rules
+}
+
+nvmf_timeout_udev_rule
+
 nvmf_hostnqn=$(getarg rd.nvmf.hostnqn -d nvmf.hostnqn=)
 if [ -n "$nvmf_hostnqn" ]; then
     echo "$nvmf_hostnqn" > /etc/nvme/hostnqn

--- a/modules.d/95nvmf/parse-nvmf-boot-connections.sh
+++ b/modules.d/95nvmf/parse-nvmf-boot-connections.sh
@@ -311,9 +311,9 @@ done
 
 if [ -e /tmp/nvmf_needs_network ] || [ -e /tmp/valid_nbft_entry_found ]; then
     echo "rd.neednet=1" > /etc/cmdline.d/nvmf-neednet.conf
+    netroot=nbft
     rm -f /tmp/nvmf_needs_network
 fi
 
-/sbin/initqueue --online --name nvmf-connect-online /sbin/nvmf-autoconnect.sh online
 /sbin/initqueue --settled --onetime --name nvmf-connect-settled /sbin/nvmf-autoconnect.sh settled
 /sbin/initqueue --timeout --onetime --name nvmf-connect-timeout /sbin/nvmf-autoconnect.sh timeout


### PR DESCRIPTION
Fixes for bsc#1210909, bsc#1211072, and bsc#1211080

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

This should be a "0-day update" for dracut in SLE15-SP5.

I created this PR against the SLE-15-SP5_GA branch, as there is no SLE-15-SP5_Update.

Notes:

 - 11f12d4 (bsc#1211072) is already included in the draft upstream PR https://github.com/dracutdevs/dracut/pull/2184
 - fc69e35 (bsc#1210909) is discussed for inclusion in the upstream PR (https://github.com/timberland-sig/dracut/pull/10), the late discussion is only about networkmanager.
 - 010925a (bsc#1211080) is pending customer verification. I've tested it successfully here. The final solution may be different / implemented in nvme-cli (https://github.com/timberland-sig/nvme-cli/issues/7).

