### PR TITLE
bsc#1214081 (SLE15-SP5:Update) 

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2061,7 +2061,13 @@ if [[ $kernel_only != yes ]]; then
         dinfo "*** Resolving executable dependencies ***"
         find "$initdir" -type f -perm /0111 -not -path '*.ko' -print0 \
             | xargs -r -0 "$DRACUT_INSTALL" ${initdir:+-D "$initdir"} ${dracutsysrootdir:+-r "$dracutsysrootdir"} -R ${DRACUT_FIPS_MODE:+-f} --
-        dinfo "*** Resolving executable dependencies done ***"
+        # shellcheck disable=SC2181
+        if (($? == 0)); then
+            dinfo "*** Resolving executable dependencies done ***"
+        else
+            dfatal "Resolving executable dependencies failed"
+            exit 1
+        fi
     fi
 
     # Now we are done with lazy resolving, always install dependencies

--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -455,6 +455,11 @@ static char *get_real_file(const char *src, bool fullyresolve)
 
         log_debug("get_real_file: readlink('%s') returns '%s'", fullsrcpath, linktarget);
 
+        if (streq(fullsrcpath, linktarget)) {
+                log_error("ERROR: '%s' is pointing to itself", fullsrcpath);
+                return NULL;
+        }
+
         if (linktarget[0] == '/') {
                 if (asprintf(&abspath, "%s%s", (sysrootdirlen ? sysrootdir : ""), linktarget) < 0)
                         return NULL;


### PR DESCRIPTION
- fix(dracut.sh): exit if resolving executable dependencies fails
- fix(dracut-install): protect against broken links pointing to themselves