### PR TITLE
fix(systemd): add new systemd-tmpfiles-setup-dev-early.service

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -83,6 +83,7 @@ install() {
         "$systemdsystemunitdir"/kmod-static-nodes.service \
         "$systemdsystemunitdir"/systemd-tmpfiles-setup.service \
         "$systemdsystemunitdir"/systemd-tmpfiles-setup-dev.service \
+        "$systemdsystemunitdir"/systemd-tmpfiles-setup-dev-early.service \
         "$systemdsystemunitdir"/systemd-ask-password-console.path \
         "$systemdsystemunitdir"/systemd-udevd-control.socket \
         "$systemdsystemunitdir"/systemd-udevd-kernel.socket \
@@ -117,6 +118,7 @@ install() {
         "$systemdsystemunitdir"/sysinit.target.wants/kmod-static-nodes.service \
         "$systemdsystemunitdir"/sysinit.target.wants/systemd-tmpfiles-setup.service \
         "$systemdsystemunitdir"/sysinit.target.wants/systemd-tmpfiles-setup-dev.service \
+        "$systemdsystemunitdir"/sysinit.target.wants/systemd-tmpfiles-setup-dev-early.service \
         "$systemdsystemunitdir"/sysinit.target.wants/systemd-sysctl.service \
         "$systemdsystemunitdir"/ctrl-alt-del.target \
         "$systemdsystemunitdir"/reboot.target \

--- a/modules.d/01systemd-tmpfiles/module-setup.sh
+++ b/modules.d/01systemd-tmpfiles/module-setup.sh
@@ -45,8 +45,11 @@ install() {
         "$systemdsystemunitdir/systemd-tmpfiles-setup.service.d/*.conf" \
         "$systemdsystemunitdir"/systemd-tmpfiles-setup-dev.service \
         "$systemdsystemunitdir/systemd-tmpfiles-setup-dev.service.d/*.conf" \
-        "$systemdsystemunitdir"/sysinit.target.wants/systemd-tmpfiles-setup-dev.service \
+        "$systemdsystemunitdir"/systemd-tmpfiles-setup-dev-early.service \
+        "$systemdsystemunitdir/systemd-tmpfiles-setup-dev-early.service.d/*.conf" \
         "$systemdsystemunitdir"/sysinit.target.wants/systemd-tmpfiles-setup.service \
+        "$systemdsystemunitdir"/sysinit.target.wants/systemd-tmpfiles-setup-dev.service \
+        "$systemdsystemunitdir"/sysinit.target.wants/systemd-tmpfiles-setup-dev-early.service \
         systemd-tmpfiles
 
     # Install the hosts local user configurations if enabled.
@@ -60,7 +63,9 @@ install() {
             "$systemdsystemconfdir"/systemd-tmpfiles-setup.service \
             "$systemdsystemconfdir/systemd-tmpfiles-setup.service.d/*.conf" \
             "$systemdsystemconfdir"/systemd-tmpfiles-setup-dev.service \
-            "$systemdsystemconfdir/systemd-tmpfiles-setup-dev.service.d/*.conf"
+            "$systemdsystemconfdir/systemd-tmpfiles-setup-dev.service.d/*.conf" \
+            "$systemdsystemconfdir"/systemd-tmpfiles-setup-dev-early.service \
+            "$systemdsystemconfdir/systemd-tmpfiles-setup-dev-early.service.d/*.conf"
     fi
 
 }


### PR DESCRIPTION
`systemd-tmpfiles-setup-dev.service`, `kmod-static-nodes.service` and `systemd-sysusers.service` have an ordering dependency on this new service since https://github.com/systemd/systemd/commit/353c849

(cherry picked from commit 7528d84de84d9c1fb7d5f54712c692600e21b044)

This will be required for the next submission of systemd-v254.2 to Factory (if nothing changes upstream), so we should merge this PR only after the v254.2 tag appears in https://github.com/openSUSE/systemd/tree/v254.2 with the new `systemd-tmpfiles-setup-dev-early.service`.
