### PR TITLE
chore(suse): disable fips and ima subpackages for i?86

### DIFF
--- a/suse/dracut.spec
+++ b/suse/dracut.spec
@@ -75,6 +75,7 @@ Dracut contains various modules which are driven by the event-based udev
 and systemd. Having root on MD, DM, LVM2, LUKS is supported as well as
 NFS, iSCSI, NBD, FCoE.
 
+%ifnarch %ix86
 %package fips
 Summary:        Dracut modules to build a dracut initramfs with an integrity check
 Group:          System/Base
@@ -88,7 +89,9 @@ Requires:       libopenssl1_1-hmac
 This package requires everything which is needed to build an
 initramfs with dracut, which does an integrity check of the kernel
 and its cryptography during startup.
+%endif
 
+%ifnarch %ix86
 %package ima
 Summary:        Dracut modules to build a dracut initramfs with IMA
 Group:          System/Base
@@ -99,6 +102,7 @@ Requires:       keyutils
 %description ima
 This package requires everything which is needed to build an
 initramfs (using dracut) which tries to load an IMA policy during startup.
+%endif
 
 %package tools
 Summary:        Tools to build a local initramfs
@@ -114,8 +118,6 @@ This package contains tools to assemble the local initrd and host configuration.
 Summary:        Dracut modules usually not required for normal operation
 Group:          System/Base
 Requires:       %{name} = %{version}-%{release}
-Requires:       evmctl
-Requires:       keyutils
 
 %description extra
 This package contains all modules that are part of dracut upstream
@@ -164,8 +166,10 @@ touch %{buildroot}%{_localstatedir}/log/dracut.log
 
 install -D -m 0644 dracut.conf.d/suse.conf.example %{buildroot}%{dracutlibdir}/dracut.conf.d/01-dist.conf
 install -m 0644 suse/99-debug.conf %{buildroot}%{_sysconfdir}/dracut.conf.d/99-debug.conf
+%ifnarch %ix86
 install -m 0644 dracut.conf.d/fips.conf.example %{buildroot}%{_sysconfdir}/dracut.conf.d/40-fips.conf
 install -m 0644 dracut.conf.d/ima.conf.example %{buildroot}%{_sysconfdir}/dracut.conf.d/40-ima.conf
+%endif
 # bsc#915218
 %ifarch s390 s390x
 install -m 0644 suse/s390x_persistent_policy.conf %{buildroot}%{_sysconfdir}/dracut.conf.d/10-persistent_policy.conf
@@ -205,41 +209,57 @@ if [ -L /var/run ] && [ -f /etc/dracut.conf.d/05-convertfs.conf ]; then
 fi
 %{?regenerate_initrd_post}
 
+%ifnarch %ix86
 %post fips
 %{?regenerate_initrd_post}
+%endif
 
+%ifnarch %ix86
 %post ima
 %{?regenerate_initrd_post}
+%endif
 
 %postun
 %{?regenerate_initrd_post}
 
+%ifnarch %ix86
 %postun fips
 %{?regenerate_initrd_post}
+%endif
 
+%ifnarch %ix86
 %postun ima
 %{?regenerate_initrd_post}
+%endif
 
 %posttrans
 %{?regenerate_initrd_posttrans}
 
+%ifnarch %ix86
 %posttrans fips
 %{?regenerate_initrd_posttrans}
+%endif
 
+%ifnarch %ix86
 %posttrans ima
 %{?regenerate_initrd_posttrans}
+%endif
 
+%ifnarch %ix86
 %files fips
 %license COPYING
 %config %{_sysconfdir}/dracut.conf.d/40-fips.conf
 %{dracutlibdir}/modules.d/01fips
+%endif
 
+%ifnarch %ix86
 %files ima
 %license COPYING
 %config %{_sysconfdir}/dracut.conf.d/40-ima.conf
 %{dracutlibdir}/modules.d/96securityfs
 %{dracutlibdir}/modules.d/97masterkey
 %{dracutlibdir}/modules.d/98integrity
+%endif
 
 %files tools
 %{_bindir}/dracut-catimages
@@ -325,6 +345,9 @@ fi
 %{dracutlibdir}/modules.d/00systemd-network-management
 %ifnarch s390 s390x
 %{dracutlibdir}/modules.d/00warpclock
+%endif
+%ifarch %ix86
+%exclude %{dracutlibdir}/modules.d/01fips
 %endif
 %{dracutlibdir}/modules.d/01systemd-ac-power
 %{dracutlibdir}/modules.d/01systemd-ask-password
@@ -435,6 +458,11 @@ fi
 %{dracutlibdir}/modules.d/95zfcp_rules
 %endif
 %{dracutlibdir}/modules.d/97biosdevname
+%ifarch %ix86
+%exclude %{dracutlibdir}/modules.d/96securityfs
+%exclude %{dracutlibdir}/modules.d/97masterkey
+%exclude %{dracutlibdir}/modules.d/98integrity
+%endif
 %{dracutlibdir}/modules.d/98dracut-systemd
 %{dracutlibdir}/modules.d/98ecryptfs
 %{dracutlibdir}/modules.d/98pollcdrom


### PR DESCRIPTION
`libkcapi-tools` and `evmctl` are required for fips and ima subpackages, but they are not being provided for i?86, breaking the package building.

Fixes: https://build.opensuse.org/package/show/openSUSE:Factory/dracut#comment-1816858

OBS test:
- https://build.opensuse.org/package/show/home:afeijoo:branches:openSUSE:Factory:spec-i586-fix/dracut
- https://build.opensuse.org/projects/home:afeijoo:branches:openSUSE:Factory:spec-i586-fix/packages/dracut/repositories/standard/binaries