### PR TITLE
chore(suse): remove obsolete fillup template (bsc#1212764)

### DIFF
--- a/suse/dracut.spec
+++ b/suse/dracut.spec
@@ -207,6 +207,10 @@ if [ -L /var/run ] && [ -f /etc/dracut.conf.d/05-convertfs.conf ]; then
     [ -d /var/lock.lockmove~ ] && rm -rf /var/lock.lockmove~ || :
     [ -d /var/run.runmove~ ] && rm -rf /var/run.runmove~ || :
 fi
+
+# remove obsolete legacy fillup template for /etc/sysconfig/kernel
+[ -f /var/adm/fillup-templates/sysconfig.kernel-mkinitrd ] && rm -f /var/adm/fillup-templates/sysconfig.kernel-mkinitrd
+
 %{?regenerate_initrd_post}
 
 %ifnarch %ix86


### PR DESCRIPTION
This pull request changes...

remove obsolete mkinitrd fillup tempate

## Changes

## Checklist
- [ X ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
bsc#1212764