### PR TITLE
Changes required for systemd-v254  (SLE15-SP6:GA)

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -83,6 +83,7 @@ install() {
         "$systemdsystemunitdir"/kmod-static-nodes.service \
         "$systemdsystemunitdir"/systemd-tmpfiles-setup.service \
         "$systemdsystemunitdir"/systemd-tmpfiles-setup-dev.service \
+        "$systemdsystemunitdir"/systemd-tmpfiles-setup-dev-early.service \
         "$systemdsystemunitdir"/systemd-ask-password-console.path \
         "$systemdsystemunitdir"/systemd-udevd-control.socket \
         "$systemdsystemunitdir"/systemd-udevd-kernel.socket \
@@ -117,6 +118,7 @@ install() {
         "$systemdsystemunitdir"/sysinit.target.wants/kmod-static-nodes.service \
         "$systemdsystemunitdir"/sysinit.target.wants/systemd-tmpfiles-setup.service \
         "$systemdsystemunitdir"/sysinit.target.wants/systemd-tmpfiles-setup-dev.service \
+        "$systemdsystemunitdir"/sysinit.target.wants/systemd-tmpfiles-setup-dev-early.service \
         "$systemdsystemunitdir"/sysinit.target.wants/systemd-sysctl.service \
         "$systemdsystemunitdir"/ctrl-alt-del.target \
         "$systemdsystemunitdir"/reboot.target \

--- a/modules.d/01systemd-tmpfiles/module-setup.sh
+++ b/modules.d/01systemd-tmpfiles/module-setup.sh
@@ -45,8 +45,11 @@ install() {
         "$systemdsystemunitdir/systemd-tmpfiles-setup.service.d/*.conf" \
         "$systemdsystemunitdir"/systemd-tmpfiles-setup-dev.service \
         "$systemdsystemunitdir/systemd-tmpfiles-setup-dev.service.d/*.conf" \
-        "$systemdsystemunitdir"/sysinit.target.wants/systemd-tmpfiles-setup-dev.service \
+        "$systemdsystemunitdir"/systemd-tmpfiles-setup-dev-early.service \
+        "$systemdsystemunitdir/systemd-tmpfiles-setup-dev-early.service.d/*.conf" \
         "$systemdsystemunitdir"/sysinit.target.wants/systemd-tmpfiles-setup.service \
+        "$systemdsystemunitdir"/sysinit.target.wants/systemd-tmpfiles-setup-dev.service \
+        "$systemdsystemunitdir"/sysinit.target.wants/systemd-tmpfiles-setup-dev-early.service \
         systemd-tmpfiles
 
     # Install the hosts local user configurations if enabled.
@@ -60,7 +63,9 @@ install() {
             "$systemdsystemconfdir"/systemd-tmpfiles-setup.service \
             "$systemdsystemconfdir/systemd-tmpfiles-setup.service.d/*.conf" \
             "$systemdsystemconfdir"/systemd-tmpfiles-setup-dev.service \
-            "$systemdsystemconfdir/systemd-tmpfiles-setup-dev.service.d/*.conf"
+            "$systemdsystemconfdir/systemd-tmpfiles-setup-dev.service.d/*.conf" \
+            "$systemdsystemconfdir"/systemd-tmpfiles-setup-dev-early.service \
+            "$systemdsystemconfdir/systemd-tmpfiles-setup-dev-early.service.d/*.conf"
     fi
 
 }

--- a/suse/dracut.spec
+++ b/suse/dracut.spec
@@ -57,8 +57,6 @@ Requires:       modutils
 Requires:       pigz
 Requires:       sed
 Requires:       systemd >= 219
-# systemd-sysvinit provides: poweroff, reboot, halt
-Requires:       systemd-sysvinit
 Recommends:     (tpm2.0-tools if tpm2-0-tss)
 Requires:       udev > 166
 Requires:       util-linux >= 2.21


### PR DESCRIPTION
Changes required with the upcoming update to systemd-v254 in SLE15-SP6. For now:

- revert(suse): fix systemd-sysvinit dependency
systemd-v254 already links `reboot`/`halt`/`poweroff`/`shutdown` with `systemctl` in the
main package, so this dependency is no longer necessary.

- fix(systemd): add new systemd-tmpfiles-setup-dev-early.service
`systemd-tmpfiles-setup-dev.service`, `kmod-static-nodes.service` and
`systemd-sysusers.service` have an ordering dependency on this new service since
https://github.com/systemd/systemd/commit/353c849


