### PR TITLE
fix(dracut.spec): do not require libgcrypt20-hmac for dracut-fips (bsc#1216059)

### DIFF
--- a/suse/dracut.spec
+++ b/suse/dracut.spec
@@ -81,7 +81,6 @@ Summary:        Dracut modules to build a dracut initramfs with an integrity che
 Group:          System/Base
 Requires:       %{name} = %{version}-%{release}
 Requires:       libcryptsetup12-hmac
-Requires:       libgcrypt20-hmac
 Requires:       libkcapi-tools
 Requires:       libopenssl1_1-hmac
 


### PR DESCRIPTION
Factory also needs to be fixed, according to bsc#1216059#c9