### PR TITLE
Correct network device naming (bsc#1192986)

### DIFF
--- a/modules.d/35network-legacy/module-setup.sh
+++ b/modules.d/35network-legacy/module-setup.sh
@@ -25,10 +25,12 @@ installkernel() {
 install() {
     local _arch
 
-    #Adding default link
-    if dracut_module_included "systemd"; then
+    # Add default link if there is no persistent network device naming
+    if [ ! -e /etc/udev/rules.d/70-persistent-net.rules ] &&\
+         dracut_module_included "systemd"; then
+
         inst_multiple -o "${systemdutildir}/network/99-default.link"
-        [[ $hostonly ]] && inst_multiple -H -o "${systemdsystemconfdir}/network/*.link"
+        [[ $hostonly ]] && inst_multiple -H -o "${systemdutilconfdir}/network/*.link"
     fi
 
     inst_multiple ip sed awk grep pgrep tr expr

--- a/modules.d/35network-manager/module-setup.sh
+++ b/modules.d/35network-manager/module-setup.sh
@@ -51,9 +51,12 @@ install() {
         inst_simple "$moddir"/nm-initrd.service "$systemdsystemunitdir"/nm-initrd.service
         inst_simple "$moddir"/nm-wait-online-initrd.service "$systemdsystemunitdir"/nm-wait-online-initrd.service
 
-        # Adding default link
-        inst_multiple -o "${systemdutildir}/network/99-default.link"
-        [[ $hostonly ]] && inst_multiple -H -o "${systemdsystemconfdir}/network/*.link"
+        # Add default link if there is no persistent network device naming
+        if [ ! -e /etc/udev/rules.d/70-persistent-net.rules ]; then
+
+            inst_multiple -o "${systemdutildir}/network/99-default.link"
+            [[ $hostonly ]] && inst_multiple -H -o "${systemdutilconfdir}/network/*.link"
+        fi
 
         $SYSTEMCTL -q --root "$initdir" enable nm-initrd.service
     fi

--- a/modules.d/95udev-rules/module-setup.sh
+++ b/modules.d/95udev-rules/module-setup.sh
@@ -40,7 +40,6 @@ install() {
         61-persistent-storage-edd.rules \
         64-btrfs.rules \
         70-uaccess.rules \
-        70-persistent-net.rules \
         71-seat.rules \
         73-seat-late.rules \
         75-net-description.rules \
@@ -55,8 +54,16 @@ install() {
     inst_rules 91-permissions.rules
     # eudev rules
     inst_rules 80-drivers-modprobe.rules
-    # legacy persistent network device name rules
-    [[ $hostonly ]] && inst_rules 70-persistent-net.rules
+
+    # only include persistent network device name rules if network is set up
+    # in the initrd
+    # Avoid interference with systemd predictable network device naming
+    if dracut_module_included "network-legacy" || dracut_module_included "network-manager"; then
+        if [ -e /etc/udev/rules.d/70-persistent-net.rules ] && \
+           ! dracut_module_included "systemd-networkd"; then
+               [[ $hostonly ]] && inst_rules 70-persistent-net.rules
+        fi
+    fi
 
     {
         for i in cdrom tape dialout floppy; do


### PR DESCRIPTION
Make the rule for persistent net device naming default in SLES. Keep the predictable names as fallback if 70-persistent-net.rules is not present but a network module is added to the initrd. Make sure that either persistent or predictable naming is applied, but never both.

This pull request changes...

This is for v055

## Changes

## Checklist
- [ x ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #