### PR TITLE
fix(dracut.sh): remove microcode check based on CONFIG_MICROCODE_[AMD|INTEL] (bsc#1217031) (055)

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -1386,23 +1386,20 @@ fi
 
 if [[ $early_microcode == yes ]]; then
     if [[ $hostonly ]]; then
-        if [[ $(get_cpu_vendor) == "AMD" ]]; then
-            check_kernel_config CONFIG_MICROCODE_AMD || unset early_microcode
-        elif [[ $(get_cpu_vendor) == "Intel" ]]; then
-            check_kernel_config CONFIG_MICROCODE_INTEL || unset early_microcode
+        if [[ $(get_cpu_vendor) == "AMD" || $(get_cpu_vendor) == "Intel" ]]; then
+            check_kernel_config CONFIG_MICROCODE || unset early_microcode
         else
             unset early_microcode
         fi
     else
-        ! check_kernel_config CONFIG_MICROCODE_AMD \
-            && ! check_kernel_config CONFIG_MICROCODE_INTEL \
+        ! check_kernel_config CONFIG_MICROCODE \
             && unset early_microcode
     fi
     # Do not complain on non-x86 architectures as it makes no sense
     case $(uname -m) in
         x86_64 | i?86)
             [[ $early_microcode != yes ]] \
-                && dwarn "Disabling early microcode, because kernel does not support it. CONFIG_MICROCODE_[AMD|INTEL]!=y"
+                && dwarn "Disabling early microcode, because kernel does not support it. CONFIG_MICROCODE!=y"
             ;;
         *) ;;
     esac


### PR DESCRIPTION
`CONFIG_MICROCODE_AMD` and `CONFIG_MICROCODE_INTEL` are hidden since https://lore.kernel.org/all/20230810160805.081212701@linutronix.de/, therefore this check is wrong and early microcode is always disabled.

(cherry picked from commit 6c80408c8644a0add1907b0593eb83f90d6247b1)
