### PR TITLE
Early preparation for systemd-v255

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -34,6 +34,7 @@ install() {
         "$systemdutildir"/systemd \
         "$systemdutildir"/systemd-coredump \
         "$systemdutildir"/systemd-cgroups-agent \
+        "$systemdutildir"/systemd-executor \
         "$systemdutildir"/systemd-shutdown \
         "$systemdutildir"/systemd-reply-password \
         "$systemdutildir"/systemd-fsck \

--- a/modules.d/95resume/module-setup.sh
+++ b/modules.d/95resume/module-setup.sh
@@ -68,7 +68,6 @@ install() {
         inst_multiple -o \
             "$systemdutildir"/system-generators/systemd-hibernate-resume-generator \
             "$systemdsystemunitdir"/systemd-hibernate-resume.service \
-            "$systemdsystemunitdir"/systemd-hibernate-resume@.service \
             "$systemdutildir"/systemd-hibernate-resume
         return 0
     fi

--- a/modules.d/95resume/module-setup.sh
+++ b/modules.d/95resume/module-setup.sh
@@ -67,6 +67,7 @@ install() {
     if dracut_module_included "systemd" && [[ -x $dracutsysrootdir$systemdutildir/systemd-hibernate-resume ]]; then
         inst_multiple -o \
             "$systemdutildir"/system-generators/systemd-hibernate-resume-generator \
+            "$systemdsystemunitdir"/systemd-hibernate-resume.service \
             "$systemdsystemunitdir"/systemd-hibernate-resume@.service \
             "$systemdutildir"/systemd-hibernate-resume
         return 0


### PR DESCRIPTION
Changes required for systemd-v255 that do not interfere with the current version, so they can be merged now to ease the preparation of the new systemd version:
- feat(systemd): install systemd-executor
- fix(resume): add new systemd-hibernate-resume.service

See #295
