### PR TITLE
Backport upstream fixes to 059

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -87,6 +87,7 @@ installkernel() {
                 "=drivers/rtc" \
                 "=drivers/soc" \
                 "=drivers/spi" \
+                "=drivers/spmi" \
                 "=drivers/usb/chipidea" \
                 "=drivers/usb/dwc2" \
                 "=drivers/usb/dwc3" \

--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -95,7 +95,8 @@ installkernel() {
                 "=drivers/usb/misc" \
                 "=drivers/usb/musb" \
                 "=drivers/usb/phy" \
-                "=drivers/scsi/hisi_sas"
+                "=drivers/scsi/hisi_sas" \
+                "=net/qrtr"
         fi
 
         awk -F: '/^\// {print $1}' "$srcmods/modules.dep" 2> /dev/null | instmods

--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -55,7 +55,7 @@ installkernel() {
             "=drivers/watchdog"
 
         instmods \
-            yenta_socket spi_pxa2xx_platform \
+            yenta_socket intel_lpss_pci spi_pxa2xx_platform \
             atkbd i8042 firewire-ohci pcmcia hv-vmbus \
             virtio virtio_ring virtio_pci pci_hyperv \
             "=drivers/pcmcia"

--- a/modules.d/91pcsc/module-setup.sh
+++ b/modules.d/91pcsc/module-setup.sh
@@ -29,7 +29,8 @@ install() {
     inst_simple "$moddir/pcscd.socket" "${systemdsystemunitdir}"/pcscd.socket
 
     inst_multiple -o \
-        pcscd
+        pcscd \
+        /etc/pkcs11/modules/opensc.module
 
     # Enable systemd type unit(s)
     for i in \

--- a/modules.d/91pcsc/pcscd.service
+++ b/modules.d/91pcsc/pcscd.service
@@ -5,7 +5,7 @@ Documentation=man:pcscd(8)
 Requires=pcscd.socket
 
 [Service]
-ExecStart=/usr/sbin/pcscd --foreground --auto-exit
+ExecStart=/usr/sbin/pcscd --foreground --auto-exit --disable-polkit
 ExecReload=/usr/sbin/pcscd --hotplug
 
 [Install]


### PR DESCRIPTION
- Fix broken `pcsc` dracut module. I have a smart card reader, so I can confirm this module is broken without these patches. More info in the upstream PR:
  - https://github.com/dracutdevs/dracut/pull/2547

- Add kernel drivers required for some ARM/RISC-V devices. Upstream PRs:
  - https://github.com/dracutdevs/dracut/pull/2531
  - https://github.com/dracutdevs/dracut/pull/2557 : already requested by MediaTek for [installation-images](https://github.com/openSUSE/installation-images/pull/669) (https://bugzilla.suse.com/show_bug.cgi?id=1216767)

- Fix for Apple SPI Keyboards, openSUSE builds `intel_lpss_pci` as a module. Upstream PR:
  - https://github.com/dracutdevs/dracut/pull/2556