### PR TITLE
fix(dracut.sh): skip README for AMD microcode generation (bsc#1217083) (SLE15-SP6:GA)

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2141,6 +2141,8 @@ if [[ $early_microcode == yes ]]; then
                 done
                 for i in $_fwdir/$_fw/$_src; do
                     [[ -e $i ]] || continue
+                    # skip README{.xz,.zst,...}
+                    str_starts "$i" "$_fwdir/$_fw/README" && continue
                     # skip gpg files
                     str_ends "$i" ".asc" && continue
                     cat "$i" >> "$_dest_dir/${ucode_dest[$idx]}"


### PR DESCRIPTION
This file was added in https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/commit/amd-ucode/README?id=89ec6198f13d1007563ff87aae5de209e993be07 and it should be skipped.

Fixes #2541
