### PR TITLE
Changes required for systemd-v255

### DIFF
--- a/modules.d/01systemd-pcrphase/module-setup.sh
+++ b/modules.d/01systemd-pcrphase/module-setup.sh
@@ -6,7 +6,7 @@
 check() {
 
     # If the binary(s) requirements are not fulfilled the module can't be installed.
-    require_binaries "$systemdutildir"/systemd-pcrphase || return 1
+    require_binaries "$systemdutildir"/systemd-pcrextend || return 1
 
     # Return 255 to only include the module, if another module requires it.
     return 255
@@ -27,7 +27,7 @@ depends() {
 install() {
 
     inst_multiple -o \
-        "$systemdutildir"/systemd-pcrphase \
+        "$systemdutildir"/systemd-pcrextend \
         "$systemdsystemunitdir"/systemd-pcrphase-initrd.service \
         "$systemdsystemunitdir/systemd-pcrphase-initrd.service.d/*.conf" \
         "$systemdsystemunitdir"/initrd.target.wants/systemd-pcrphase-initrd.service

--- a/suse/README.susemaint
+++ b/suse/README.susemaint
@@ -313,6 +313,7 @@ PR      Commit message
 2404    fix(multipath): explicitly check if hostonly_cmdline is yes
 2451    fix(base): correct handling of quiet in loginit
 2524    fix(dracut.sh): abort if Bash is in POSIX mode
+2526    fix(systemd-pcrphase): rename systemd-pcrphase binary to systemd-pcrextend
 2527    fix(resume): add new systemd-hibernate-resume.service
 2531    feat(kernel-modules): add Qualcomm IPC router to enable USB
 2532    fix(dracut-systemd): use `DRACUT_VERSION` instead of `VERSION`


### PR DESCRIPTION
Changes required for systemd-v255:
- fix(systemd-pcrphase): rename systemd-pcrphase binary to systemd-pcrextend
- fix(crypt): correct systemd-cryptsetup binary path

The sole purpose of this PR is to be ready when systemd-v255 is submitted to Factory, so it should not be merged before that happens.

Follow-up to https://github.com/openSUSE/dracut/pull/299
Closes https://github.com/openSUSE/dracut/issues/295
