### PR TITLE
chore(suse): update SUSE maintainers doc

### DIFF
--- a/suse/README.susemaint
+++ b/suse/README.susemaint
@@ -79,3 +79,254 @@ Date:   Wed Sep 21 11:54:17 2022 +0200
 [2] Factory OBS repo: https://build.opensuse.org/package/show/openSUSE:Factory/dracut
 [3] Factory OBS Devel repo: https://build.opensuse.org/package/show/Base:System/dracut
 
+
+Current status of the SUSE/059 branch (Tumbleweed)
+==================================================
+
+1. Upstream commits that were already merged
+
+The following list shows the commits merged (those marked with "MERGED") since
+the upgrade to dracut-059 (0aa08f0e docs: update NEWS.md and AUTHORS), extracted
+using `git log --oneline 0aa08f0e..HEAD`:
+
+        4980bad3 fix(configure): misleading error if C compiler is not installed
+        de8ac630 fix(github): update format of labeler
+MERGED  4971f443 fix(systemd-journald): add systemd-sysusers dependency
+MERGED  4d594210 fix(dracut-initramfs-restore.sh): do not set selinux labels if disabled
+MERGED  1586af09 fix(systemd-repart): correct undefined $libdir
+        bddffeda fix(overlayfs): split overlayfs mount in two steps
+MERGED  1c762c0d fix(pkcs11): delete trailing dot on libcryptsetup-token-systemd-pkcs11.so
+        856e7acd docs: update NEWS.md and AUTHORS
+MERGED  b2af8c8b fix(install.d): do not create initramfs if the supplied image is UKI
+MERGED  bee1c482 feat(systemd): install systemd-executor
+        6acfecae chore: remove unnecessary shellcheck disable for SC1087
+MERGED  6c80408c fix(dracut.sh): remove microcode check based on CONFIG_MICROCODE_[AMD|INTEL]
+        b4e23ce4 fix(release): maintain dracut-version.sh in the source tree
+        23389f6d docs: set KVERSION for running test suite
+        0b81e8eb chore: remove unnecessary shellcheck disable for SC2154
+MERGED  16645633 feat(install.d): allow using dracut in combination with ukify
+        6f78e5de test: support disabling KVM by setting NO_KVM
+        65f0ef52 test: set QEMU machine for ARM and PowerPC
+        f29e428b fix(test): only use QEMU machine q35 on x86
+        fb7d5ec4 test: support /boot/vmlinux
+        a1e63b18 test: log qemu calls to ease debugging
+        bf97572b test: introduce overridable ARCH variable in run-qemu
+        9a18f133 fix(test): use bash for jobs -r parameter
+        8e9d89d9 ci: also run integration test on Ubuntu
+        31c4d284 feat(Makefile): allow setting dracut version via environment variables
+        ddf63231 fix: codespell
+        028f7632 test: fix skipcpio path for installed binary
+        dbee4f37 test: skip test 98 if dracut-util is not available
+        c0321c90 test: make package libdir configurable
+        f9939d0e test: make dracut directory configurable
+MERGED  7528d84d fix(systemd): add new systemd-tmpfiles-setup-dev-early.service
+MERGED  570b9d40 fix(systemd-udevd): add missing override paths
+MERGED  32f6f364 fix(dracut-install): protect against broken links pointing to themselves
+MERGED  b2c6b584 fix(dracut.sh): exit if resolving executable dependencies fails
+        fffeaded feat(dracut): add --sbat option to add sbat policy to UKI
+        af3076a1 ci: run all local tests on all containers (including Gentoo)
+        699d51c5 chore(dracut-init.sh): remove support for obsolete syntax
+        83eccc74 ci: change the order of lint jobs as lint_shell is more likely to fail
+        d55fa823 ci: migrate from systemd-boot to systemd-utils in Gentoo container
+        403f4e8e ci: do not run test container generation on forked repos by default
+MERGED  16855765 refactor(install): log about missing firmware only once
+        c46513fb test: increase test VM memory from 512M to 1024M to avoid OOM killer
+MERGED  a804945f fix(integrity): do not require ls
+        e278a965 ci: match comment with code
+        9e1e9245 ci: automate release generation
+        a3758704 ci: allow the release generation script to compute the next release
+        5cdd4b35 refactor(Makefile): improve AUTHORS and CONTRIBUTORS targets
+MERGED  6c9f403f fix(dracut-init.sh): `module_check` method ignores `forced` option
+MERGED  c4e6eaf9 feat(systemd-rfkill): remove module
+MERGED  f11e8fff fix(man): add missing initrd-root-device.target to flow chart
+MERGED  1b53bb62 fix(dracut-init.sh): use the local _ret variable
+        273e4811 ci: install util-linux-systemd and systemd-boot into openSUSE container
+        dbdab2d8 fix(dracut.sh): shellcheck warning SC1004
+MERGED  33a66ed0 fix(dracut.sh): use gawk for strtonum
+MERGED  6af3fcfd fix(man): remove duplicate entry
+        81d78c4e ci: release
+MERGED  52351cfa feat(livenet): add memory size check depending on live image size
+MERGED  15d4f60e chore(gentoo.conf): remove examples to avoid confusion
+MERGED  b7ef1302 fix(modsign): load keys to correct keyring
+MERGED  179e1a99 fix(dmsquash-live-autooverlay): specify filesystemtype when it is already known
+MERGED  a71b905e chore: remove git2spec.pl, it is no longer used
+MERGED  9aa332ca fix(fs-lib): remove quoting form the first argument of the e2fsck call
+MERGED  f5cc202e fix(Makefile): remove leftover rpm build rules
+MERGED  ffc766d2 fix(Makefile): no longer upload to kernel.org
+MERGED  b490f6f7 feat(nvmf): add code for parsing the NBFT
+MERGED  f07117d6 fix(nvmf): support /etc/nvme/config.json
+MERGED  902f3a8f fix(nvmf): install 8021q module unconditionally
+MERGED  17b8649e fix(install.d): respect even more kernel-install vars, plus style fixes
+MERGED  a037634a fix(install.d): respect more kernel-install env variables
+MERGED  09d3ec16 fix(dracut.sh): also prevent fsfreeze for tmpfs
+        4000a1ec fix(dmsquash-live): allow other fstypes
+        995ac6f8 test(DMSQUASH): add test for NTFS
+        d96754ea test(16): check for failure after each sub-test run
+MERGED  dfa408c9 fix(bluetooth): make bluetooth rules more strict
+MERGED  e84d65c5 fix(bluetooth): add missing files
+MERGED  8079ceaf fix(bluetooth): include it if Appearance matches the value assigned for keyboard
+        0ecb0388 fix(bluetooth): warn user instead of including it by default
+MERGED  765e69ce fix(systemd-timedated): correct typo in override path
+MERGED  2d083021 fix(systemd-resolved): correct typo in override path
+MERGED  f0dc7ec9 fix(systemd-networkd): correct typos in override paths
+MERGED  3e2f685e fix(dracut-init.sh): correct check in `is_qemu_virtualized` function
+MERGED  7ed765dd fix(btrfs): do not require module via cmdline when --no-kernel
+MERGED  2b47a2ef fix(btrfs): add missing cmdline function
+        2ff7b470 ci: conditionally add tgt to Gentoo container
+        d06153f8 ci: re-enable lvm on Gentoo container
+        a9ecb5e3 ci: disable initramfs generation inside Gentoo container
+        5803ece5 ci: add extra packages for tests to Gentoo container
+        6fd6b36d ci: switching the musl test to 18 (uefi)
+        af31df4b test(ISCSI): make test-30 use the test dracut modules
+        dcf4665b ci: add dependencies to Debian container
+        ec2c7e1a test(UEFI): add test case for UEFI boot
+MERGED  c1b3f88d docs: remove rd.lvm.snapsize and rd.lvm.snapshot
+MERGED  4235c035 fix(Makefile): execute command -v instead of which
+MERGED  e2f961a2 fix(network-legacy): typo
+MERGED  3f8f115a fix(network,dbus): improve dependency checking
+MERGED  cd6f683d fix(systemd-pcrphase): only include systemd-pcrphase-initrd.service
+MERGED  1ef00735 fix(systemd-tmpfiles): do not include systemd-tmpfiles-clean.timer
+MERGED  eff2a939 fix(systemd-journald): do not include systemd-journal-flush.service
+MERGED  925febf8 fix(systemd): do not include systemd-random-seed.service
+        c1588995 fix(dracut.sh): correct path for UEFI stub on split-usr systems
+MERGED  aa20bbb5 feat(dracut-init.sh): do not print by default if an udev rule is skipped
+        c5e036b1 test: move more makeroot dependencies into test-makeroot dracut module
+MERGED  afb5717e fix(kernel-modules): add interconnect drivers
+        d244b316 test(LVM-THIN): avoid thin pool size warning
+        739b9e1b ci: cleanup containers
+        ae7cd94b test: add empty default test_cleanup implementation
+        f1346763 test: move more common test code to test-functions
+        5ac581ef fix(resolve-deps): check the existing file—not the source
+MERGED  07af8d58 fix(dracut-lib.sh): remove successful finished initqueue scripts
+MERGED  7310a641 fix(udev-rules): remove firmware.rules
+        fc182ed8 docs: change ext3 to ext4
+MERGED  2a26eec5 fix(dracut.sh): silence the output of hardlinking files by default
+        c8a703aa fix(github): exempt issues in a milestone
+MERGED  07b49a3e fix(virtiofs): add virtio_pci kernel module to virtiofs
+        c08ae406 ci: install multipath-tools into openSuse container
+        d1187543 test: remove references of dhcpd3 from tests
+        1843c16c test: move test condition to test_check
+        006890a2 test: upgrade to ext4
+MERGED  86c8a5a7 fix(dracut-systemd): rootfs-generator cannot write outside of generator dir
+MERGED  acfa793b fix(dracut-systemd): check and create generator dir outside of inner function
+MERGED  a7c04716 fix(dracut-systemd): do not hardcode the systemd generator directory
+        6cd41ab5 ci: add more packages to allow testing more dracut containers
+        19c54395 ci: simplify and sort
+        6178a9d8 fix(dracut.sh): handle imagebase for uefi
+MERGED  67591e88 fix(dracut-functions): avoid calling grep with PCRE (-P)
+MERGED  260883d9 fix(dracut-initramfs-restore.sh): handle /etc/machine-id empty or uninitialized
+MERGED  971b302d fix(lsinitrd.sh): handle /etc/machine-id empty or uninitialized
+MERGED  97fe0976 fix(dracut.sh): handle /etc/machine-id empty or uninitialized
+        48c2cb45 feat(systemd-creds): introducing the systemd-creds module
+MERGED  71e391eb fix(systemd-networkd): add missing conf files and services
+MERGED  a62e895d fix(dracut-functions.sh): convert mmcblk to the real kernel module name
+MERGED  297525c5 fix(multipath): remove dependency on multipathd.socket
+MERGED  1300a930 feat(lsinitrd): notify user on missing compressor
+MERGED  a0d14d3b fix(99base): adjust to allow mksh as initrd shell
+MERGED  8b951d20 fix(base): do not quote $CLINE in the `set` command
+MERGED  df2458a6 fix(systemd-ac-power): correct systemd-ac-power binary path
+MERGED  f32e95bc fix(dracut.sh): use dynamically uefi's sections offset
+MERGED  e9b47742 fix(lvmthinpool-monitor): activate lvm thin pool before extend its size
+        aca51203 chore(deps): bump luizm/action-sh-checker from 0.5.0 to 0.6.0
+MERGED  0e780720 fix(dmsquash-live): restore compatibility with earlier releases
+MERGED  1ddcb137 fix(dracut.sh): kmoddir does not handle trailing /
+MERGED  6d554d9b fix(udev-rules): remove old eudev specific rule
+MERGED  d648bf80 fix(udev-rules): remove old redhat specific rule
+MERGED  6a33e677 fix(udev-rules): remove old edd_id extra rules
+MERGED  1edc41af fix(udev-rules): remove old debian specific rules
+        8f9ad068 feat(test): nfs_fetch_url test into nfs test
+        966b6cec fix(url-lib.sh): nfs_already_mounted() with trailing slash in nfs path
+        f9bcd4d2 ci: use CodeQL instead of LGTM
+MERGED  ae88e029 feat(dracut): use log level indicator in console output
+MERGED  df381b7e feat(kernel-modules): driver support for macbook keyboards
+        131822e2 fix(dracut-install): prevent possible infinite recursion with suppliers
+MERGED  f3a7172d build: remove rpm spec file and build rules
+MERGED  89269d23 fix(kernel-modules): add UFS drivers
+MERGED  87a76dbb fix(kernel-modules): use modalias info in get_dev_module()
+MERGED  c5dca3d6 fix(crypt): add missing libraries
+MERGED  61ceb35f revert(network-manager): avoid restarting NetworkManager
+MERGED  a6dd5bfb fix(dracut.sh): handle sbsign errors for UEFI builds
+MERGED  8602df70 fix(dracut.sh): handle out of space error for UEFI builds
+MERGED  726d56ca fix(network): IPv6: don't wait for RA for static IPv6 assignments
+MERGED  b074216b fix(network-legacy): always include af_packet
+MERGED  7ff255a4 fix(network): don't assume prefix length 64 by default
+MERGED  c3b65a49 fix(iscsi): prefix syntax for static iBFT IPv6 addresses
+MERGED  aa5d9526 fix(iscsi): install 8021q module unconditionally
+        3de4c731 feat(dracut-install): add fw_devlink suppliers as module dependencies
+        f0c3b683 refactor(dracut-install): add Hashmap cleanup function
+        8ea8cf5f refactor(dracut-install): add function to install one dependent module
+        88aeca2a chore(deps): bump luizm/action-sh-checker from 0.2.2 to 0.5.0
+MERGED  16931f52 chore(shfmt): update to pass with shfmt v3.5.1
+MERGED  d777dd3d fix(fips): move fips-boot script to pre-pivot
+MERGED  ab26ad2c fix(fips): only unmount /boot if it was mounted by the fips module
+MERGED  68d0653e feat(fips): add progress messages
+MERGED  1fabbb64 fix(fips): do not blindly remove /boot
+        c95075e2 chore(base): remove support for <udev-176
+MERGED  d6cef3f2 fix(plymouth): remove /etc/system-release dependency
+        e3a7112b feat(resume): also consider resume= in the cmdline as enabling hibernation
+MERGED  d8a9a73d fix(network-manager): add "After" dependency on dbus.service
+MERGED  15970768 fix(fido2): libfido2.so depends on libz.so
+MERGED  9a531ca0 fix(dracut-install): continue parsing if ldd prints "cannot execute binary file"
+MERGED  7b530f26 fix: make iso-scan trigger udev events
+        ab07f6d1 ci: enable test 60
+        3d7c0ffb fix(test): rename test 60
+        5e846cb1 fix(test): improve test 60
+        8f44740f fix(test): remove leftover link file from server rootfs
+        9fb64d96 fix(test): assign fixed address to bridge
+        462d9b92 fix(test): bump DHCP timeout to 30 seconds
+        da959483 fix(test): remove check on dhclient support for --timeout
+        d3993c7d fix(test): adapt multinic test for new NetworkManager versions
+MERGED  70aeb4c1 fix(install): do not undef _FILE_OFFSET_BITS
+        18c5fb6a chore(deps): bump docker/build-push-action from 3 to 4
+MERGED  6f4a5c90 fix(dracut.sh): --sysroot option broken if global variables not set in conf
+MERGED  823de8fe refactor(dracut-init.sh): remove redundant "dracut" from "dracut module" prints
+MERGED  a10078a5 feat(dracut-init.sh): specify if a module cannot be found or cannot be installed
+MERGED  1f84ff88 fix(lsinitrd.sh): handle filenames with special characters
+MERGED  eb75861c fix(dracut-systemd): remove unused argument
+MERGED  a109c612 feat(lvm): always include all drivers that LVM can use
+MERGED  1aafcab9 fix(dracut-init.sh): correct typo in comment
+MERGED  cda6b00a fix(dracut.sh): correct --help and --version exit codes
+MERGED  e971c788 refactor(virtiofs): remove exit after die
+        3c16c76f ci: fix Gentoo container used for testing
+MERGED  e3e8108e fix(crypt-gpg): do not use always --card-status
+        f6bb4a36 docs(RELEASE.md): update release docs
+        b060945c ci: disable test 50
+MERGED  88fe9205 fix: shellcheck 0.8.0
+MERGED  93339444 fix(dmsquash-live): live:/dev/*
+MERGED  10cf8e46 fix(load_fstype): avoid false positive searchs
+MERGED  08b63a25 fix: shellcheck 0.8.0
+        94dcac7c refactor(dracut-install): strerror(errno) -> %m
+        efd4ca27 perf(dracut-install): don't strdup() environment block
+        77226cb4 perf(dracut-install): don't reallocate {src,dst}path in hmac_install()
+        a20556f0 perf(dracut-install): don't strdup() excessively for dracut_install()
+        e7ed8337 perf(dracut-install): stat() w/unused buf -> access(F_OK) in dracut-install
+        751a110f perf(dracut-install): multiple single-character strstr()s -> strpbrk()
+        1e5237dd chore: remove src/install/hashmap.lo
+MERGED  9dbbebb1 feat(network-wicked): remove module
+
+
+2. Commits from upstream pull requests that were already merged
+
+PR      Commit message
+----    --------------
+2342    fix(systemd-sysext): handle confexts and correct extensions search path
+2404    fix(multipath): explicitly check if hostonly_cmdline is yes
+2451    fix(base): correct handling of quiet in loginit
+2524    fix(dracut.sh): abort if Bash is in POSIX mode
+2527    fix(resume): add new systemd-hibernate-resume.service
+2531    feat(kernel-modules): add Qualcomm IPC router to enable USB
+2532    fix(dracut-systemd): use `DRACUT_VERSION` instead of `VERSION`
+2533    fix(install.d): do not generate a new initrd if any INITRD_FILE is provided
+2547    fix(pcsc): add opensc load module file
+2547    fix(pcsc): add --disable-polkit to pcscd.service
+2556    fix(90kernel-modules): add intel_lpss_pci for MacBook Pro 2017
+2557    feat(kernel-modules): install SPMI modules on ARM/RISC-V
+2559    feat(install.d): add sort-key field to rescue BLS entries
+2560    feat(resume): do not attempt to install systemd-hibernate-resume@.service
+2593    fix(dracut.sh): do not add device if find_block_device returns an error
+2593    feat(dracut.sh): protect push_host_devs function
+2607    fix(dracut): correct regression with multiple `rd.break=` options
+2611    fix(livenet): propagate error code
+2611    fix(livenet): check also `content-length` from live image header
+2611    fix(livenet): split `imgsize` calculation to avoid misleading error message
+


### PR DESCRIPTION
Since dracut-059 has been around for quite some time, and we added a lot of patches from the upstream master branch and also from PRs that haven't been merged yet, it would be helpful to document what the current status is in SUSE.
