### PR TITLE
fix(overlayfs): split overlayfs mount in two steps (bsc#1219778)

### DIFF
--- a/modules.d/90overlayfs/module-setup.sh
+++ b/modules.d/90overlayfs/module-setup.sh
@@ -15,4 +15,5 @@ installkernel() {
 
 install() {
     inst_hook mount 01 "$moddir/mount-overlayfs.sh"
+    inst_hook pre-mount 01 "$moddir/prepare-overlayfs.sh"
 }

--- a/modules.d/90overlayfs/mount-overlayfs.sh
+++ b/modules.d/90overlayfs/mount-overlayfs.sh
@@ -3,24 +3,11 @@
 type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
 
 getargbool 0 rd.live.overlay.overlayfs && overlayfs="yes"
-getargbool 0 rd.live.overlay.reset -d -y reset_overlay && reset_overlay="yes"
 getargbool 0 rd.live.overlay.readonly -d -y readonly_overlay && readonly_overlay="--readonly" || readonly_overlay=""
 
 ROOTFLAGS="$(getarg rootflags)"
 
 if [ -n "$overlayfs" ]; then
-    if ! [ -e /run/rootfsbase ]; then
-        mkdir -m 0755 -p /run/rootfsbase
-        mount --bind "$NEWROOT" /run/rootfsbase
-    fi
-
-    mkdir -m 0755 -p /run/overlayfs
-    mkdir -m 0755 -p /run/ovlwork
-    if [ -n "$reset_overlay" ] && [ -h /run/overlayfs ]; then
-        ovlfsdir=$(readlink /run/overlayfs)
-        info "Resetting the OverlayFS overlay directory."
-        rm -r -- "${ovlfsdir:?}"/* "${ovlfsdir:?}"/.* > /dev/null 2>&1
-    fi
     if [ -n "$readonly_overlay" ] && [ -h /run/overlayfs-r ]; then
         ovlfs=lowerdir=/run/overlayfs-r:/run/rootfsbase
     else

--- a/modules.d/90overlayfs/prepare-overlayfs.sh
+++ b/modules.d/90overlayfs/prepare-overlayfs.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
+
+getargbool 0 rd.live.overlay.overlayfs && overlayfs="yes"
+getargbool 0 rd.live.overlay.reset -d -y reset_overlay && reset_overlay="yes"
+
+if [ -n "$overlayfs" ]; then
+    if ! [ -e /run/rootfsbase ]; then
+        mkdir -m 0755 -p /run/rootfsbase
+        mount --bind "$NEWROOT" /run/rootfsbase
+    fi
+
+    mkdir -m 0755 -p /run/overlayfs
+    mkdir -m 0755 -p /run/ovlwork
+    if [ -n "$reset_overlay" ] && [ -h /run/overlayfs ]; then
+        ovlfsdir=$(readlink /run/overlayfs)
+        info "Resetting the OverlayFS overlay directory."
+        rm -r -- "${ovlfsdir:?}"/* "${ovlfsdir:?}"/.* > /dev/null 2>&1
+    fi
+fi

--- a/suse/README.susemaint
+++ b/suse/README.susemaint
@@ -94,7 +94,7 @@ using `git log --oneline 0aa08f0e..HEAD`:
 MERGED  4971f443 fix(systemd-journald): add systemd-sysusers dependency
 MERGED  4d594210 fix(dracut-initramfs-restore.sh): do not set selinux labels if disabled
 MERGED  1586af09 fix(systemd-repart): correct undefined $libdir
-        bddffeda fix(overlayfs): split overlayfs mount in two steps
+MERGED  bddffeda fix(overlayfs): split overlayfs mount in two steps
 MERGED  1c762c0d fix(pkcs11): delete trailing dot on libcryptsetup-token-systemd-pkcs11.so
         856e7acd docs: update NEWS.md and AUTHORS
 MERGED  b2af8c8b fix(install.d): do not create initramfs if the supplied image is UKI


### PR DESCRIPTION
This commit splits the creation of required overlayfs underlaying directories and the actual overlayfs mount. This way it is still possible to mount the overlayfs with the generated sysroot.mount that dmsquash-live creates.

The overlayfs tree is created in a pre-mount hook so it is executed before sysroot.mount is started. Otherwise sysroot.mount starts and fails before mount hooks are executed.

Signed-off-by: David Cassany <dcassany@suse.com>

(cherry picked from commit bddffedae038ceca263a904e40513a6e92f1b558)
