### PR TITLE
fix(dracut-util): do not call `strcmp` if the `value` argument is NULL (bsc#1219841)

### DIFF
--- a/src/util/util.c
+++ b/src/util/util.c
@@ -273,7 +273,7 @@ static int getargs(int argc, char **argv)
                 cmdline = next_arg(cmdline, &key, &value);
                 if (strcmp(key, search_key) == 0) {
                         if (search_value) {
-                                if (strcmp(value, search_value) == 0) {
+                                if (value && strcmp(value, search_value) == 0) {
                                         printf("%s\n", value);
                                         found_value = true;
                                 }

--- a/suse/README.susemaint
+++ b/suse/README.susemaint
@@ -325,6 +325,7 @@ PR      Commit message
 2560    feat(resume): do not attempt to install systemd-hibernate-resume@.service
 2593    fix(dracut.sh): do not add device if find_block_device returns an error
 2593    feat(dracut.sh): protect push_host_devs function
+2607    fix(dracut-util): do not call strcmp if the value argument is NULL
 2607    fix(dracut): correct regression with multiple `rd.break=` options
 2611    fix(livenet): propagate error code
 2611    fix(livenet): check also `content-length` from live image header


### PR DESCRIPTION
fix(dracut-util): do not call `strcmp` if the `value` argument is NULL

The behavior of `strcmp` is undefined if any of its arguments is NULL, which
can lead to a segfault depending on the implementation. So, this check is
required to be able to use `getargs` with options where the value is optional,
e.g., with `rd.break`.
