### PR TITLE
fix(dracut.spec): update dracut-fips requirements (bsc#1219869)

### DIFF
--- a/suse/dracut.spec
+++ b/suse/dracut.spec
@@ -80,9 +80,7 @@ NFS, iSCSI, NBD, FCoE.
 Summary:        Dracut modules to build a dracut initramfs with an integrity check
 Group:          System/Base
 Requires:       %{name} = %{version}-%{release}
-Requires:       libcryptsetup12-hmac
 Requires:       libkcapi-tools
-Requires:       libopenssl1_1-hmac
 
 %description fips
 This package requires everything which is needed to build an


### PR DESCRIPTION
The hmac files have been merged into their main packages.
