### PR TITLE
fix(zfcp_rules): correct shellcheck regression when parsing ccw args (bsc#1220485)

### DIFF
--- a/modules.d/95zfcp_rules/parse-zfcp.sh
+++ b/modules.d/95zfcp_rules/parse-zfcp.sh
@@ -63,7 +63,8 @@ for zfcp_arg in $(getargs root=) $(getargs resume=); do
         if [ -n "$ccw_arg" ]; then
             OLDIFS="$IFS"
             IFS="-"
-            set -- "$ccw_arg"
+            # shellcheck disable=SC2086
+            set -- $ccw_arg
             IFS="$OLDIFS"
             _wwpn=${4%:*}
             _lun=${4#*:}

--- a/suse/README.susemaint
+++ b/suse/README.susemaint
@@ -334,4 +334,5 @@ PR      Commit message
 2614    fix(dracut-systemd): replace `rd.udev.log-priority` with `rd.udev.log_level`
 2618    fix(i18n): handle keymap includes with `--sysroot`
 2618    fix(dracut-init.sh): handle decompress with `--sysroot`
+2630    fix(zfcp_rules): correct shellcheck regression when parsing ccw args
 


### PR DESCRIPTION
Fixes 032ecd95c94b77f3f08237e0f765b355dacb9573