### PR TITLE
fix(zfcp_rules): correct shellcheck regression when parsing ccw args (bsc#1220485) (SLE15-SP6:GA) 

### DIFF
--- a/modules.d/95zfcp_rules/parse-zfcp.sh
+++ b/modules.d/95zfcp_rules/parse-zfcp.sh
@@ -63,7 +63,8 @@ for zfcp_arg in $(getargs root=) $(getargs resume=); do
         if [ -n "$ccw_arg" ]; then
             OLDIFS="$IFS"
             IFS="-"
-            set -- "$ccw_arg"
+            # shellcheck disable=SC2086
+            set -- $ccw_arg
             IFS="$OLDIFS"
             _wwpn=${4%:*}
             _lun=${4#*:}


### PR DESCRIPTION
Fixes 032ecd95c94b77f3f08237e0f765b355dacb9573
