### PR TITLE
fix(dracut.spec): do not check if fillup template exists at %post end

### DIFF
--- a/suse/dracut.spec
+++ b/suse/dracut.spec
@@ -206,7 +206,7 @@ if [ -L /var/run ] && [ -f /etc/dracut.conf.d/05-convertfs.conf ]; then
 fi
 
 # remove obsolete legacy fillup template for /etc/sysconfig/kernel
-[ -f /var/adm/fillup-templates/sysconfig.kernel-mkinitrd ] && rm -f /var/adm/fillup-templates/sysconfig.kernel-mkinitrd
+rm -f /var/adm/fillup-templates/sysconfig.kernel-mkinitrd
 
 %{?regenerate_initrd_post}
 


### PR DESCRIPTION
If the test returns false, the %post script also exits with error and the rpm build fails.

Issue detected on the IBS after the build of ae26ad5d5931c663dde5577d6a511f8bd5504ff5 failed.

Fixes f6bfaa30a628638a8d6274da120ca5c944fb23de