### PR TITLE
fix(suse-initrd): clean return of installkernel() (bsc#1223467) (SLE15-SP6:GA)

### DIFF
--- a/modules.d/99suse-initrd/module-setup.sh
+++ b/modules.d/99suse-initrd/module-setup.sh
@@ -60,4 +60,6 @@ installkernel() {
     if [[ "$all_mods" ]]; then
         hostonly= dracut_instmods $all_mods
     fi
+
+    return 0
 }


### PR DESCRIPTION
Since d2f6f445edb5de033d52ece0e982db38ac2614e2, the result code returned by dracut-install is propagated again, so `installkernel()` must return 0 to keep backwards compatibility if `dracut_instmods()` fails.
