### PR TITLE
fix(install.d): skip if dracut is not the initrd or UKI generator

### DIFF
--- a/install.d/50-dracut.install
+++ b/install.d/50-dracut.install
@@ -13,7 +13,7 @@ if ! [[ ${KERNEL_INSTALL_MACHINE_ID-x} ]]; then
 fi
 
 # Do not attempt to create initramfs if the supplied image is already a UKI
-if [[ "$KERNEL_INSTALL_IMAGE_TYPE" = "uki" ]]; then
+if [[ $KERNEL_INSTALL_IMAGE_TYPE == "uki" ]]; then
     exit 0
 fi
 

--- a/install.d/50-dracut.install
+++ b/install.d/50-dracut.install
@@ -17,6 +17,13 @@ if [[ $KERNEL_INSTALL_IMAGE_TYPE == "uki" ]]; then
     exit 0
 fi
 
+# Skip this plugin if we're using a different generator. If nothing is specified,
+# assume we're wanted since we're installed.
+if [[ ${KERNEL_INSTALL_INITRD_GENERATOR:-dracut} != "dracut" ]] \
+    && [[ ${KERNEL_INSTALL_UKI_GENERATOR:-dracut} != "dracut" ]]; then
+    exit 0
+fi
+
 # Mismatching the install layout and the --uefi/--no-uefi opts just creates a mess.
 if [[ $KERNEL_INSTALL_LAYOUT == "uki" && -n $KERNEL_INSTALL_STAGING_AREA ]]; then
     BOOT_DIR_ABS="$KERNEL_INSTALL_STAGING_AREA"
@@ -39,7 +46,7 @@ elif [[ $KERNEL_INSTALL_LAYOUT == "bls" && -n $KERNEL_INSTALL_STAGING_AREA ]]; t
     else
         exit 0
     fi
-else
+elif [[ ${KERNEL_INSTALL_INITRD_GENERATOR:-dracut} == "dracut" ]]; then
     # No layout information, use users --uefi/--no-uefi preference
     UEFI_OPTS=""
     if [[ -d $BOOT_DIR_ABS ]]; then
@@ -48,6 +55,8 @@ else
         BOOT_DIR_ABS="/boot"
         IMAGE="initrd-${KERNEL_VERSION}"
     fi
+else
+    exit 0
 fi
 
 ret=0

--- a/install.d/51-dracut-rescue.install
+++ b/install.d/51-dracut-rescue.install
@@ -50,7 +50,7 @@ fi
 [[ -n $PRETTY_NAME ]] || PRETTY_NAME="Linux $KERNEL_VERSION"
 
 SORT_KEY="$IMAGE_ID"
-[[ -z "$SORT_KEY" ]] && SORT_KEY="$ID"
+[[ -z $SORT_KEY ]] && SORT_KEY="$ID"
 
 if [[ ${KERNEL_INSTALL_MACHINE_ID+x} ]]; then
     MACHINE_ID=$KERNEL_INSTALL_MACHINE_ID
@@ -142,7 +142,7 @@ case "$COMMAND" in
                 echo "title      $PRETTY_NAME - Rescue Image"
                 echo "version    $KERNEL_VERSION"
                 echo "machine-id $MACHINE_ID"
-                [[ -n "$SORT_KEY" ]] && echo "sort-key   $SORT_KEY"
+                [[ -n $SORT_KEY ]] && echo "sort-key   $SORT_KEY"
                 echo "options    ${BOOT_OPTIONS[*]} rd.auto=1"
                 echo "linux      $BOOT_DIR/linux"
                 echo "initrd     $BOOT_DIR/initrd"


### PR DESCRIPTION
Preparation work to avoid interfering with other initrd generators.