### PR TITLE
fix(systemd-ask-password): no graphical output in aarch64 (bsc#1224404)

### DIFF
--- a/modules.d/01systemd-ask-password/module-setup.sh
+++ b/modules.d/01systemd-ask-password/module-setup.sh
@@ -19,6 +19,19 @@ check() {
 # Module dependency requirements.
 depends() {
 
+    if [[ $hostonly ]]; then
+        # A password cannot be entered if there is no graphical output during boot,
+        # as is the case in aarch64, where efifb does not work with qemu-system-aarch64:
+        # - virtio-gpu-pci does not expose a linear framebuffer
+        # - virtio-vga is not supported
+        # - ramfb is not enough
+        # Therefore, depend on the drm module if virtio_gpu is loaded on the system.
+        if [[ ${DRACUT_ARCH:-$(uname -m)} == arm* || ${DRACUT_ARCH:-$(uname -m)} == aarch64 ]] \
+            && grep -r -q "virtio:d00000010v" /sys/bus/virtio/devices/*/modalias 2> /dev/null; then
+            echo drm
+        fi
+    fi
+
     # Return 0 to include the dependent module(s) in the initramfs.
     return 0
 

--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -30,6 +30,16 @@ depends() {
         if grep -q "tpm2-device=" "$dracutsysrootdir"/etc/crypttab; then
             deps+=" tpm2-tss"
         fi
+        # A password cannot be entered if there is no graphical output during boot,
+        # as is the case in aarch64, where efifb does not work with qemu-system-aarch64:
+        # - virtio-gpu-pci does not expose a linear framebuffer
+        # - virtio-vga is not supported
+        # - ramfb is not enough
+        # Therefore, depend on the drm module if virtio_gpu is loaded on the system.
+        if [[ ${DRACUT_ARCH:-$(uname -m)} == arm* || ${DRACUT_ARCH:-$(uname -m)} == aarch64 ]] \
+            && grep -r -q "virtio:d00000010v" /sys/bus/virtio/devices/*/modalias 2> /dev/null; then
+            deps+=" drm"
+        fi
     fi
     echo "$deps"
     return 0

--- a/suse/README.susemaint
+++ b/suse/README.susemaint
@@ -351,4 +351,5 @@ were already merged
 
 a45048b8 fix(dracut): move hooks directory from /usr/lib to /var/lib
 424717af fix: /etc/modprobe.d --> /run/modprobe.d (partially reverted)
+4cc962aa fix(systemd-ask-password): no graphical output in aarch64
 


### PR DESCRIPTION
A password cannot be entered if there is no graphical output during boot, as is the case in aarch64, where efifb does not work with qemu-system-aarch64:
- virtio-gpu-pci does not expose a linear framebuffer
- virtio-vga is not supported
- ramfb is not enough

Therefore, depend on the drm module if virtio_gpu is loaded on the system.

(cherry picked from commit https://github.com/dracut-ng/dracut-ng/commit/4cc962aa0989c53822f4bd6c5431488c7707124e)