### PR TITLE
perf(drm): group dracut_instmods calls

### DIFF
--- a/suse/README.susemaint
+++ b/suse/README.susemaint
@@ -329,6 +329,7 @@ PR      Commit message
 2571    fix(dracut-install): memory leak in `--modalias` option
 2573    fix(dracut-install): release memory allocated for regular expressions
 2574    fix(dracut-install): memory leak in two `hashmap_put` calls if key exists
+2577    perf(drm): group dracut_instmods calls
 2593    fix(dracut.sh): do not add device if find_block_device returns an error
 2593    feat(dracut.sh): protect push_host_devs function
 2601    feat(tpm2-tss): add tpm2.target and systemd-tpm2-generator


### PR DESCRIPTION
This module loops over many bus devices, and calls `dracut_instmods` for each
one. E.g., on a Lenovo Thinkpad laptop:

```
> for i in /sys/bus/{pci/devices,platform/devices,virtio/devices,soc/devices/soc?,vmbus/devices}/*/modalias; do [[ -e $i ]] && [[ -n $(< "$i") ]]  && echo $i; done | wc -l
79
```

Every call to `dracut_instmods` spawns a `dracut-install` process, which in the
previous example means calling `dracut-install` 79 times using the same
arguments.

If any call to `dracut-install` fails, dracut continues its execution (even the
errors are not shown, because it's called with `--silent`). Therefore, let's
take the contents of all the `modalias` files into an array and call
`dracut-install` only once, adding also the `-o` argument, so if any of the
modules cannot be installed, `dracut-install` does not stop.

Upstream PR #2577 (already merged in the new upstream https://github.com/dracut-ng/dracut-ng/commit/80f2caf4f5ee47a708b5e4bd65c28e3f8ff1b9c8)