### PR TITLE
fix(dracut-install): continue parsing if ldd prints "cannot be preloaded" (bsc#1208690) (SLE15-SP6:Update)

### DIFF
--- a/src/install/dracut-install.c
+++ b/src/install/dracut-install.c
@@ -589,7 +589,7 @@ static int resolve_deps(const char *src)
                         break;
 
                 if (strstr(buf, "cannot be preloaded"))
-                        break;
+                        continue;
 
                 if (strstr(buf, destrootdir))
                         break;


### PR DESCRIPTION
When /etc/ld.so.preload contains a non-existing library, `ldd` prints the following output:

```
> ldd /usr/lib64/libfido2.so.1.12.0
ERROR: ld.so: object '/usr/lib64/libfoo.so' from /etc/ld.so.preload cannot be preloaded (cannot open shared object file): ignored.
ERROR: ld.so: object '/usr/lib64/libfoo.so' from /etc/ld.so.preload cannot be preloaded (cannot open shared object file): ignored.
	linux-vdso.so.1 (0x00007ffd477f5000)
	libcbor.so.0.10 => /lib64/libcbor.so.0.10 (0x00007f34062dd000)
	libcrypto.so.3 => /lib64/libcrypto.so.3 (0x00007f3405e00000)
	libudev.so.1 => /lib64/libudev.so.1 (0x00007f34062af000)
	libhidapi-hidraw.so.0 => /lib64/libhidapi-hidraw.so.0 (0x00007f34062a6000)
	libz.so.1 => /lib64/libz.so.1 (0x00007f340628c000)
	libc.so.6 => /lib64/libc.so.6 (0x00007f3405c05000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f3406336000)
ERROR: ld.so: object '/usr/lib64/libfoo.so' from /etc/ld.so.preload cannot be preloaded (cannot open shared object file): ignored.
> echo $?
0
ERROR: ld.so: object '/usr/lib64/libfoo.so' from /etc/ld.so.preload cannot be preloaded (cannot open shared object file): ignored.
```

If `dracut-install` stops parsing the `ldd` output, the initrd will not contain all the required dependencies.

(cherry picked from commit https://github.com/dracut-ng/dracut-ng/commit/ace9e1b58c09e1e91621ad2219f7a96b7edbbd38)
