### PR TITLE
fix(mdraid): try to assemble the missing raid device (bsc#1226412) (SLFO)

### DIFF
--- a/suse/README.susemaint
+++ b/suse/README.susemaint
@@ -356,4 +356,5 @@ b5a35f9d feat(zfcp_rules): remove zfcp handling consolidated in s390-tools
 22f51730 fix(znet): append to udev rules so each rd.znet_ifname is effective
 2d8fa8be refactor(ifcfg): delete code duplication using iface_get_subchannels()
 457e66e6 feat(ifcfg): minimize s390-specific network configuration aspects
+3fd43858 fix(mdraid): try to assemble the missing raid device
 


### PR DESCRIPTION
If some raid devices with specified UUIDs fail to be assembled in initrd, we will try to assemble them again in this script to avoid system falling into emergency mode. This patch is created because we can offen see mdadm command failure during boot because of timing issue introduced between mdadm and udevd.

(cherry picked from commit https://github.com/dracut-ng/dracut-ng/commit/3fd4385873bb82ae9f759ef5af32bf1732d298b4)
