### PR TITLE
fix(mdraid): try to assemble the missing raid device (bsc#1226412) (SL-Micro-6.0:Update)

### DIFF
--- a/suse/README.susemaint
+++ b/suse/README.susemaint
@@ -337,3 +337,8 @@ PR      Commit message
 2618    fix(dracut-init.sh): handle decompress with `--sysroot`
 2630    fix(zfcp_rules): correct shellcheck regression when parsing ccw args
 
+3. Commits from the new https://github.com/dracut-ng/dracut-ng upstream that
+were already merged
+
+3fd43858 fix(mdraid): try to assemble the missing raid device
+


### PR DESCRIPTION
If some raid devices with specified UUIDs fail to be assembled in initrd, we will try to assemble them again in this script to avoid system falling into emergency mode. This patch is created because we can offen see mdadm command failure during boot because of timing issue introduced between mdadm and udevd.

(cherry picked from commit https://github.com/dracut-ng/dracut-ng/commit/3fd4385873bb82ae9f759ef5af32bf1732d298b4)
