### PR TITLE
feat(crypt): force the inclusion of crypttab entries with x-initrd.attach (bsc#1226529) (SLE15-SP6:Update)

### DIFF
--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -132,7 +132,7 @@ install() {
             forceentry=""
             while [ $# -gt 0 ]; do
                 case $1 in
-                    force)
+                    force | x-initrd.attach)
                         forceentry="yes"
                         break
                         ;;


### PR DESCRIPTION
dracut has a "hidden" and undocumented `force` crypttab option (added with commit b7058d0ce5e99cbc80b5f760a0b654d3ff03c094). This option forces the inclusion of a crypttab entry in the initrd, which is useful in some cases where the filesystem check (for whatever reason) does not report a required encrypted device as "crypto_LUKS".

On the other hand, systemd provides the `x-initrd.attach` crypttab option since v245. Excerpt from `crypttab(5)`:

```
x-initrd.attach

Setup this encrypted block device in the initrd, similarly to systemd.mount(5)
units marked with x-initrd.mount.
```

This crypttab option is commonly used to mark encrypted block devices that contain filesystems mounted in the initrd. So, this patch aims to make use of this well-known systemd crypttab option to match the functionality provided by the not so well-known dracut crypttab option.

(cherry picked from commit https://github.com/dracut-ng/dracut-ng/commit/61ab3386e83a9bd219dcaa05c6499fec56d092b8)