### PR TITLE
fix(dracut-functions.sh): only return block devices from get_persistent_dev

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -295,8 +295,7 @@ get_persistent_dev() {
         /dev/disk/by-partlabel/* \
         /dev/disk/by-id/* \
         /dev/disk/by-path/*; do
-        [[ -e $i ]] || continue
-        [[ $i == /dev/mapper/control ]] && continue
+        [[ -b $i ]] || continue
         [[ $i == /dev/mapper/mpath* ]] && continue
         _tmp=$(get_maj_min "$i")
         if [ "$_tmp" = "$_dev" ]; then

--- a/suse/README.susemaint
+++ b/suse/README.susemaint
@@ -12,6 +12,7 @@ branch. Currently, these active maintenance branches are:
 - SLE-15-SP5_Update     -> SLE 15 SP5 (based on SUSE/055 plus some specific patches)
 - SLE-15-SP6_Update     -> SLE 15 SP6
 - SL-Micro-6.0_Update   -> SL Micro 6.0
+- SLFO_Main             -> SUSE Linux Framework One
 - SUSE/059              -> Tumbleweed
 
 Rules:
@@ -373,4 +374,4 @@ b5a35f9d feat(zfcp_rules): remove zfcp handling consolidated in s390-tools
 457e66e6 feat(ifcfg): minimize s390-specific network configuration aspects
 3fd43858 fix(mdraid): try to assemble the missing raid device
 61ab3386 feat(crypt): force the inclusion of crypttab entries with x-initrd.attach
-
+6611c6e4 fix(dracut-functions.sh): only return block devices from get_persistent_dev


### PR DESCRIPTION
With udev 256, there are now directories such as
/dev/disk/by-path/pci-0000:02:00.0-nvme-1-part/ which match here.

In case a nonexisting file/device was passed to get_persistent_dev, it returned the first directory it looked at because both have maj:min 0:0. This accidental conversion from garbage to a sensible looking path leads to weird behaviour later.

Instead of filtering out directories explicitly switch the check to only return block devices, which also takes care of the character special /dev/mapper/control.

(cherry picked from commit https://github.com/dracut-ng/dracut-ng/commit/6611c6e4a0166bec50cc567b708ec7265dc82682)