### PR TITLE
fix(dracut): ldd output borked with `--sysroot` (bsc#1228659)

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -104,6 +104,17 @@ if ! [[ $libdirs ]]; then
     export libdirs
 fi
 
+# ldd needs LD_LIBRARY_PATH pointing to the libraries within the sysroot directory
+if [[ -n $dracutsysrootdir ]]; then
+    for lib in $libdirs; do
+        mapfile -t -d '' lib_subdirs < <(find "$lib" -type d -print0 2> /dev/null)
+        for lib_subdir in "${lib_subdirs[@]}"; do
+            LD_LIBRARY_PATH="${LD_LIBRARY_PATH:+"$LD_LIBRARY_PATH":}$dracutsysrootdir$lib_subdir"
+        done
+    done
+    export LD_LIBRARY_PATH
+fi
+
 # helper function for check() in module-setup.sh
 # to check for required installed binaries
 # issues a standardized warning message


### PR DESCRIPTION
dracut-install calls ldd to resolve dependencies, but when the `--sysroot` option is used, ldd is not performing the search within the sysroot directory. To fix this issue, the `LD_LIBRARY_PATH` variable needs to be properly set to the directories containing shared libraries within the specified sysroot directory.

E.g., running dracut with `--sysroot` produces an initrd without the required systemd shared libraries when the version between the host system and the sysroot directory differs:

```
localhost:~ # ldd /.snapshots/9/snapshot/usr/lib/systemd/systemd | grep libsystemd
    libsystemd-core-256.so => not found
    libsystemd-shared-256.so => not found
localhost:~ # export LD_LIBRARY_PATH=/.snapshots/9/snapshot/usr/lib64/systemd
localhost:~ # ldd /.snapshots/9/snapshot/usr/lib/systemd/systemd | grep libsystemd
    libsystemd-core-256.so => /.snapshots/9/snapshot/usr/lib64/systemd/libsystemd-core-256.so (0x00007f817b600000)
    libsystemd-shared-256.so => /.snapshots/9/snapshot/usr/lib64/systemd/libsystemd-shared-256.so (0x00007f817b000000)
```

More details on the upstream PR: https://github.com/dracut-ng/dracut-ng/pull/567

We need to fix [bsc#1228659](https://bugzilla.opensuse.org/show_bug.cgi?id=1228659) as soon as possible and upstream is not responding at the desired pace (correction for easily offended readers: i.e., at the pace we need specifically with this critical issue that causes a system to be unable to boot after an update).