### PR TITLE
fix(dracut): ldd output borked with `--sysroot` (bsc#1228659) (SLFO)

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -104,6 +104,17 @@ if ! [[ $libdirs ]]; then
     export libdirs
 fi
 
+# ldd needs LD_LIBRARY_PATH pointing to the libraries within the sysroot directory
+if [[ -n $dracutsysrootdir ]]; then
+    for lib in $libdirs; do
+        mapfile -t -d '' lib_subdirs < <(find "$lib" -type d -print0 2> /dev/null)
+        for lib_subdir in "${lib_subdirs[@]}"; do
+            LD_LIBRARY_PATH="${LD_LIBRARY_PATH:+"$LD_LIBRARY_PATH":}$dracutsysrootdir$lib_subdir"
+        done
+    done
+    export LD_LIBRARY_PATH
+fi
+
 # helper function for check() in module-setup.sh
 # to check for required installed binaries
 # issues a standardized warning message

--- a/suse/README.susemaint
+++ b/suse/README.susemaint
@@ -362,3 +362,4 @@ b5a35f9d feat(zfcp_rules): remove zfcp handling consolidated in s390-tools
 61ab3386 feat(crypt): force the inclusion of crypttab entries with x-initrd.attach
 6611c6e4 fix(dracut-functions.sh): only return block devices from get_persistent_dev
 6c99c073 feat(systemd*): include systemd config files from /usr/lib/systemd
+e0b87682 fix(dracut): ldd output borked with `--sysroot`


### PR DESCRIPTION
Same as #362, for SLFO.

(cherry picked from commit https://github.com/dracut-ng/dracut-ng/commit/e0b876823d9c608db7132cab9e5edd62543a27ae)

