### PR TITLE
ci(suse.conf.example): change log levels (jsc#PED-12922)

### DIFF
--- a/dracut.conf.d/suse.conf.example
+++ b/dracut.conf.d/suse.conf.example
@@ -12,3 +12,5 @@ compress="zstd -3 -T0 -q"
 i18n_vars="/etc/sysconfig/language:RC_LANG-LANG,RC_LC_ALL-LC_ALL /etc/sysconfig/console:CONSOLE_UNICODEMAP-FONT_UNIMAP,CONSOLE_FONT-FONT,CONSOLE_SCREENMAP-FONT_MAP /etc/sysconfig/keyboard:KEYTABLE-KEYMAP"
 omit_drivers+=" i2o_scsi "
 
+stdloglvl="3"
+sysloglvl="4"


### PR DESCRIPTION
Reduce default standard log verbosity from `info` to `warning`, and increase syslog verbosity from none to `info`.

This is just a proposal to adjust the log verbosity (IMHO excessive). Suggestions are welcome.

CC @mwilck @fbuihuu