### PR TITLE
fix(dasd-rules): handle all possible options in `rd.dasd` (bsc#1230110) (SLE15-SP6:Update)

### DIFF
--- a/modules.d/95dasd_rules/parse-dasd.sh
+++ b/modules.d/95dasd_rules/parse-dasd.sh
@@ -35,7 +35,7 @@ for dasd_arg in $(getargs rd.dasd=); do
                 done
                 ;;
             *)
-                IFS="." read -r sid ssid chan _ <<< "${dev%(ro)}"
+                IFS="." read -r sid ssid chan _ <<< "${dev%(*}"
                 allow_device "$(printf "%01x.%01x.%04x" $((16#$sid)) $((16#$ssid)) $((16#$chan)))"
                 ;;
         esac


### PR DESCRIPTION
The current code only handles `(ro)` (e.g.: `rd.dasd=0.0.0202(ro)`), but not the other possible options `diag`, `erplog` and `failfast` [1] (e.g.: `rd.dasd=0.0.0202(diag)`, and their combination using `:` (e.g.: `rd.dasd=0.0.0202(ro:failfast)`), which causes a parse error in the next `printf`:

```
dracut-cmdline[258]: //lib/dracut/hooks/cmdline/30-parse-dasd.sh: line 39: 16#0203(diag): syntax error in expression (error token is "(diag)")
```

[1] https://www.ibm.com/docs/en/linux-on-systems?topic=d-setup-4
