### PR TITLE
fix(dracut): do not add all lib subdirs to `LD_LIBRARY_PATH` with `--sysroot` (bsc#1230354) (SLFO)

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -107,10 +107,7 @@ fi
 # ldd needs LD_LIBRARY_PATH pointing to the libraries within the sysroot directory
 if [[ -n $dracutsysrootdir ]]; then
     for lib in $libdirs; do
-        mapfile -t -d '' lib_subdirs < <(find "$lib" -type d -print0 2> /dev/null)
-        for lib_subdir in "${lib_subdirs[@]}"; do
-            LD_LIBRARY_PATH="${LD_LIBRARY_PATH:+"$LD_LIBRARY_PATH":}$dracutsysrootdir$lib_subdir"
-        done
+        LD_LIBRARY_PATH="${LD_LIBRARY_PATH:+"$LD_LIBRARY_PATH":}$dracutsysrootdir$lib"
     done
     export LD_LIBRARY_PATH
 fi

--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -264,6 +264,7 @@ EOF
     # Install library file(s)
     _arch=${DRACUT_ARCH:-$(uname -m)}
     inst_libdir_file \
-        {"tls/$_arch/",tls/,"$_arch/",}"libnss_*"
+        {"tls/$_arch/",tls/,"$_arch/",}"libnss_*" \
+        {"tls/$_arch/",tls/,"$_arch/",}"systemd/libsystemd*.so"
 
 }

--- a/suse/README.susemaint
+++ b/suse/README.susemaint
@@ -363,3 +363,5 @@ b5a35f9d feat(zfcp_rules): remove zfcp handling consolidated in s390-tools
 6611c6e4 fix(dracut-functions.sh): only return block devices from get_persistent_dev
 6c99c073 feat(systemd*): include systemd config files from /usr/lib/systemd
 e0b87682 fix(dracut): ldd output borked with `--sysroot`
+d0c82322 fix(dracut): do not add all lib subdirs to `LD_LIBRARY_PATH` with `--sysroot`
+921792f2 feat(systemd): always install libsystemd libraries


### PR DESCRIPTION
On systems with too many library subdirectories, the current approach causes `Argument list too long errors`, and the initrd also fails to build.

This patch does not fix the original issue by itself (i.e., libsystemd libs not found), so all the dracut modules that require libraries stored in subdirectories must explicitly install them using `inst_libdir_file`, which already successfully handles the `--sysroot` prefix.

