### PR TITLE
fix(nvmf): require NVMeoF modules (bsc#1230468) (SLFO)

### DIFF
--- a/modules.d/95nvmf/module-setup.sh
+++ b/modules.d/95nvmf/module-setup.sh
@@ -3,8 +3,6 @@
 # called by dracut
 check() {
     require_binaries nvme jq || return 1
-    [ -f /etc/nvme/hostnqn ] || return 255
-    [ -f /etc/nvme/hostid ] || return 255
 
     is_nvmf() {
         local _dev=$1
@@ -36,6 +34,8 @@ check() {
     }
 
     [[ $hostonly ]] || [[ $mount_needs ]] && {
+        [ -f /etc/nvme/hostnqn ] || return 255
+        [ -f /etc/nvme/hostid ] || return 255
         pushd . > /dev/null
         for_each_host_dev_and_slaves is_nvmf
         local _is_nvmf=$?
@@ -130,8 +130,8 @@ install() {
         _nvmf_args=$(cmdline)
         [[ "$_nvmf_args" ]] && printf "%s" "$_nvmf_args" >> "${initdir}/etc/cmdline.d/95nvmf-args.conf"
     fi
-    inst_simple "/etc/nvme/hostnqn"
-    inst_simple "/etc/nvme/hostid"
+    inst_simple -H "/etc/nvme/hostnqn"
+    inst_simple -H "/etc/nvme/hostid"
 
     inst_multiple ip sed
 

--- a/modules.d/95nvmf/module-setup.sh
+++ b/modules.d/95nvmf/module-setup.sh
@@ -68,8 +68,9 @@ depends() {
 
 # called by dracut
 installkernel() {
-    instmods nvme_fc lpfc qla2xxx
-    hostonly="" instmods nvme_tcp nvme_fabrics 8021q
+    instmods nvme_fc nvme_tcp nvme_rdma lpfc qla2xxx
+    # 802.1q VLAN may be set up in Firmware later. Include the module always.
+    hostonly="" instmods 8021q
 }
 
 # called by dracut

--- a/suse/README.susemaint
+++ b/suse/README.susemaint
@@ -365,3 +365,6 @@ b5a35f9d feat(zfcp_rules): remove zfcp handling consolidated in s390-tools
 e0b87682 fix(dracut): ldd output borked with `--sysroot`
 d0c82322 fix(dracut): do not add all lib subdirs to `LD_LIBRARY_PATH` with `--sysroot`
 921792f2 feat(systemd): always install libsystemd libraries
+54cd6479 fix(nvmf): move /etc/nvme/host{nqn,id} requirement to hostonly
+41332702 fix(nvmf): require NVMeoF modules
+3748ed4d fix(nvmf): install (only) required nvmf modules


### PR DESCRIPTION
On some minimal OS images, adding the `nvmf` dracut module to the initrd does not fail, although the required nvme kernel modules are not shipped with the image. That implies that users didn't see any errors when building the initrd, so they expect booting from NVMe-oF to work, but it obviously fails.

Fixes added:
- https://github.com/dracut-ng/dracut-ng/commit/54cd6479 fix(nvmf): move /etc/nvme/host{nqn,id} requirement to hostonly
- https://github.com/dracut-ng/dracut-ng/commit/41332702 fix(nvmf): require NVMeoF modules
- https://github.com/dracut-ng/dracut-ng/commit/3748ed4d fix(nvmf): install (only) required nvmf modules
