### PR TITLE
fix(systemd): copy 20-systemd-stub.conf into the initrd

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -131,6 +131,7 @@ install() {
         "$systemdsystemunitdir"/system.slice \
         "$systemdsystemunitdir"/-.slice \
         "$tmpfilesdir"/systemd.conf \
+        "$tmpfilesdir"/20-systemd-stub.conf \
         journalctl systemctl \
         echo swapoff \
         kmod insmod rmmod modprobe modinfo depmod lsmod \

--- a/modules.d/01systemd-tmpfiles/module-setup.sh
+++ b/modules.d/01systemd-tmpfiles/module-setup.sh
@@ -38,6 +38,7 @@ install() {
         "$tmpfilesdir/static-nodes-permissions.conf" \
         "$tmpfilesdir/systemd-tmp.conf" \
         "$tmpfilesdir/systemd.conf" \
+        "$tmpfilesdir/20-systemd-stub.conf" \
         "$tmpfilesdir/var.conf" \
         "$systemdsystemunitdir"/systemd-tmpfiles-clean.service \
         "$systemdsystemunitdir/systemd-tmpfiles-clean.service.d/*.conf" \

--- a/suse/README.susemaint
+++ b/suse/README.susemaint
@@ -387,3 +387,4 @@ d2ade8a6 fix(dm): remove 59-persistent-storage-dm.rules
 a1c51af1 fix(dracut): don't apply aggressive strip to kernel modules
 ad36b61e fix(dracut.sh): omit compressed kernel modules from find searching exec files
 bfa00c2a fix(pcsc): add libpcsclite_real.so.*
+0df92885 fix(systemd-tmpfiles): copy 20-systemd-stub.conf into the initrd


### PR DESCRIPTION
New tmpfiles conf snippet split from systemd.conf (https://github.com/systemd/systemd/commit/408ab988dbf6723871afd3503d11bd0deb50f846), required for systemd-v257 to persist sd-stub provided PCR signature and public key .
