### PR TITLE
Fixes for booting from iSCSI offload with bnx2i (bsc#1228086) (SLFO)

### DIFF
--- a/man/dracut.cmdline.7.asc
+++ b/man/dracut.cmdline.7.asc
@@ -879,6 +879,14 @@ iscsistart -b --param node.session.timeo.replacement_timeout=30
 **rd.iscsi.testroute=0**:
     Turn off checking, if the route to the iSCSI target IP is possible before trying to login.
 
+**rd.iscsi.transport=__<transport_name>__**::
+    Set the iSCSI transport name (see man:iscsiadm[8,external]). iSCSI offload
+    transports like **bnx2i** don't need the network to be up in order to bring
+    up iSCSI connections. This parameter indicates that network setup can be
+    skipped in the initramfs, which makes booting with iSCSI offload cards
+    faster and more reliable. This parameter currently only has an effect for
+    _<transport_name>=bnx2i_.
+
 FCoE
 ~~~~
 **rd.fcoe=0**::

--- a/modules.d/95iscsi/iscsiroot.sh
+++ b/modules.d/95iscsi/iscsiroot.sh
@@ -64,7 +64,6 @@ handle_firmware() {
         if [ "$retry" -lt "$ifaces" ]; then
             retry=$((retry + 1))
             echo $retry > /tmp/session-retry
-            return 1
         else
             rm /tmp/session-retry
         fi

--- a/modules.d/95iscsi/module-setup.sh
+++ b/modules.d/95iscsi/module-setup.sh
@@ -54,6 +54,7 @@ install_ibft() {
                 echo -n "rd.iscsi.ibft=1 "
             fi
             echo -n "rd.iscsi.firmware=1 "
+            [ -z "$ibft_mod" ] || echo -n "rd.iscsi.transport=$ibft_mod "
         fi
     done
 }

--- a/modules.d/95iscsi/parse-iscsiroot.sh
+++ b/modules.d/95iscsi/parse-iscsiroot.sh
@@ -28,6 +28,7 @@ if [ -z "$netroot" ]; then
 fi
 [ -z "$iscsiroot" ] && iscsiroot=$(getarg iscsiroot=)
 [ -z "$iscsi_firmware" ] && getargbool 0 rd.iscsi.firmware -y iscsi_firmware && iscsi_firmware="1"
+[ -z "$iscsi_transport" ] && iscsi_transport=$(getarg rd.iscsi.transport=)
 
 [ -n "$iscsiroot" ] && [ -n "$iscsi_firmware" ] && die "Mixing iscsiroot and iscsi_firmware is dangerous"
 
@@ -79,7 +80,7 @@ fi
 # iscsi_firmware does not need argument checking
 if [ -n "$iscsi_firmware" ]; then
     if [ "$root" != "dhcp" ] && [ "$netroot" != "dhcp" ]; then
-        [ -z "$netroot" ] && netroot=iscsi:
+        [ -z "$netroot" ] && [ "$iscsi_transport" != bnx2i ] && netroot=iscsi:
     fi
     modprobe -b -q iscsi_boot_sysfs 2> /dev/null
     modprobe -b -q iscsi_ibft

--- a/suse/README.susemaint
+++ b/suse/README.susemaint
@@ -12,6 +12,7 @@ branch. Currently, these active maintenance branches are:
 - SLE-15-SP5_Update     -> SLE 15 SP5 (based on SUSE/055 plus some specific patches)
 - SLE-15-SP6_Update     -> SLE 15 SP6
 - SL-Micro-6.0_Update   -> SL Micro 6.0
+- SL-Micro-6.1_Update   -> SL Micro 6.1
 - SLFO_Main             -> SUSE Linux Framework One
 - SUSE/059              -> Tumbleweed
 
@@ -389,3 +390,5 @@ ad36b61e fix(dracut.sh): omit compressed kernel modules from find searching exec
 bfa00c2a fix(pcsc): add libpcsclite_real.so.*
 0df92885 fix(systemd-tmpfiles): copy 20-systemd-stub.conf into the initrd
 c79fc8fd fix(dracut): rework timeout for devices added via --mount and --add-device
+cc2c48a0 fix(iscsi): don't require network setup for bnx2i
+f30cf46e fix(iscsi): attempt iSCSI login before all interfaces are up


### PR DESCRIPTION
Backport of https://github.com/dracut-ng/dracut-ng/pull/1121 for SLFO
