### PR TITLE
 feat(livenet): get live image size from TFTP servers (bsc#1235912) (SLFO)

### DIFF
--- a/modules.d/90livenet/livenetroot.sh
+++ b/modules.d/90livenet/livenetroot.sh
@@ -17,20 +17,31 @@ liveurl="${netroot#livenet:}"
 info "fetching $liveurl"
 
 if getargbool 0 'rd.writable.fsimg'; then
-    imgheader=$(curl -sIL "$liveurl")
-
-    # shellcheck disable=SC2181
-    ret=$?
-    if [ $ret != 0 ]; then
-        warn "failed to get live image header: error $ret"
-    else
-        imgheaderlen=$(echo "$imgheader" | sed -n 's/[cC]ontent-[lL]ength: *\([[:digit:]]*\).*/\1/p')
+    if str_starts "$liveurl" "tftp"; then
+        # we need to pass -v to get tftp tsize value in stderr
+        imgheader=$(curl -vsIL "$liveurl" 2>&1)
+        # curl returns a non-zero exit status in this case
+        ret=$?
+        imgheaderlen=$(echo "$imgheader" | sed -n 's/\* got option=(tsize) value=(*\([[:digit:]]*\).*/\1/p')
         if [ -z "$imgheaderlen" ]; then
-            warn "failed to get 'Content-Length' header from live image"
-        else
-            imgsize=$((imgheaderlen / (1024 * 1024)))
-            check_live_ram $imgsize
+            warn "failed to get 'tsize' header from TFTP live image: error $ret"
         fi
+    else
+        imgheader=$(curl -sIL "$liveurl")
+        ret=$?
+        if [ $ret != 0 ]; then
+            warn "failed to get live image header: error $ret"
+        else
+            imgheaderlen=$(echo "$imgheader" | sed -n 's/[cC]ontent-[lL]ength: *\([[:digit:]]*\).*/\1/p')
+            if [ -z "$imgheaderlen" ]; then
+                warn "failed to get 'Content-Length' header from live image"
+            fi
+        fi
+    fi
+
+    if [ -n "$imgheaderlen" ]; then
+        imgsize=$((imgheaderlen / (1024 * 1024)))
+        check_live_ram $imgsize
     fi
 fi
 

--- a/suse/README.susemaint
+++ b/suse/README.susemaint
@@ -390,5 +390,6 @@ ad36b61e fix(dracut.sh): omit compressed kernel modules from find searching exec
 bfa00c2a fix(pcsc): add libpcsclite_real.so.*
 0df92885 fix(systemd-tmpfiles): copy 20-systemd-stub.conf into the initrd
 c79fc8fd fix(dracut): rework timeout for devices added via --mount and --add-device
+93df9ad2 feat(livenet): get live image size from TFTP servers
 cc2c48a0 fix(iscsi): don't require network setup for bnx2i
 f30cf46e fix(iscsi): attempt iSCSI login before all interfaces are up


### PR DESCRIPTION
2nd part of #389 for SLFO.
