### PR TITLE
fix(network-legacy): do not require pgrep when using wicked (bsc#1236982) (SLE15-SP6:Update)

### DIFF
--- a/modules.d/35network-legacy/ifup.sh
+++ b/modules.d/35network-legacy/ifup.sh
@@ -677,6 +677,10 @@ for p in $(getargs ip=); do
                 do_dhcp -4
                 ;;
             single-dhcp)
+                if command -v wicked > /dev/null; then
+                    warn "DHCP in parallel on all available interfaces not available with wicked."
+                    exit 1
+                fi
                 do_dhcp_parallel -4
                 exit 0
                 ;;

--- a/modules.d/35network-legacy/module-setup.sh
+++ b/modules.d/35network-legacy/module-setup.sh
@@ -2,7 +2,7 @@
 
 # called by dracut
 check() {
-    require_binaries ip sed awk grep pgrep tr expr || return 1
+    require_binaries ip sed awk grep tr expr || return 1
 
     require_any_binary arping arping2 wicked || return 1
     require_any_binary dhclient wicked || return 1
@@ -34,22 +34,26 @@ install() {
         [[ $hostonly ]] && inst_multiple -H -o "${systemdnetworkconfdir}/*.link"
     fi
 
-    inst_multiple ip sed awk grep pgrep tr expr
-    inst -o dhclient
+    inst_multiple ip sed awk grep tr expr
+    if command -v wicked > /dev/null; then
+        inst wicked
+    else
+        inst_multiple dhclient pgrep
+        inst_simple -H "/etc/dhclient.conf"
+        cat "$moddir/dhclient.conf" >> "${initdir}/etc/dhclient.conf"
+    fi
 
     inst_multiple -o arping arping2
     if command -v arping > /dev/null; then
         strstr "$(arping 2>&1)" "ARPing 2" && mv "$initdir/bin/arping" "$initdir/bin/arping2"
     fi
-    inst_multiple -o wicked
+
     inst_multiple -o ping ping6
     inst_multiple -o teamd teamdctl teamnl
     inst_simple /etc/libnl/classid
     inst_script "$moddir/ifup.sh" "/sbin/ifup"
     inst_script "$moddir/dhcp-multi.sh" "/sbin/dhcp-multi.sh"
     inst_script "$moddir/dhclient-script.sh" "/sbin/dhclient-script"
-    inst_simple -H "/etc/dhclient.conf"
-    cat "$moddir/dhclient.conf" >> "${initdir}/etc/dhclient.conf"
     inst_hook pre-udev 60 "$moddir/net-genrules.sh"
     inst_hook cmdline 92 "$moddir/parse-ibft.sh"
     inst_hook cmdline 95 "$moddir/parse-vlan.sh"

--- a/modules.d/40network/module-setup.sh
+++ b/modules.d/40network/module-setup.sh
@@ -2,6 +2,7 @@
 
 # called by dracut
 check() {
+    require_binaries ip sed awk grep || return 1
     return 255
 }
 
@@ -42,7 +43,7 @@ install() {
     inst_simple "$moddir/net-lib.sh" "/lib/net-lib.sh"
     inst_hook pre-udev 50 "$moddir/ifname-genrules.sh"
     inst_hook cmdline 91 "$moddir/dhcp-root.sh"
-    inst_multiple ip sed awk grep pgrep tr
+    inst_multiple ip sed awk grep
     inst_multiple -o arping arping2
     dracut_need_initqueue
 }


### PR DESCRIPTION
#400 for SLE15-SP6