### PR TITLE
fix(90kernel-modules): explicitly include xhci-pci-renesas (bsc#1238258)

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -38,12 +38,15 @@ installkernel() {
         hostonly='' instmods \
             hid_generic unix
 
+        # xhci-pci-renesas is needed for the USB to be available during
+        # initrd on platforms with such USB controllers since Linux
+        # 6.12-rc1 (commit 25f51b76f90f).
         hostonly=$(optional_hostonly) instmods \
             ehci-hcd ehci-pci ehci-platform \
             ohci-hcd ohci-pci \
             uhci-hcd \
             usbhid \
-            xhci-hcd xhci-pci xhci-plat-hcd \
+            xhci-hcd xhci-pci xhci-pci-renesas xhci-plat-hcd \
             "=drivers/hid" \
             "=drivers/tty/serial" \
             "=drivers/input/serio" \

--- a/suse/README.susemaint
+++ b/suse/README.susemaint
@@ -393,3 +393,4 @@ c79fc8fd fix(dracut): rework timeout for devices added via --mount and --add-dev
 93df9ad2 feat(livenet): get live image size from TFTP servers
 cc2c48a0 fix(iscsi): don't require network setup for bnx2i
 f30cf46e fix(iscsi): attempt iSCSI login before all interfaces are up
+20cc20d2 fix(90kernel-modules): explicitly include xhci-pci-renesas


### PR DESCRIPTION
Since Linux v6.12-rc1 (commit 25f51b76f90f), xhci-pci no longer depends on xhci-pci-renesas, causing the Renesas driver to be omitted during initramfs generation (when built as a module).

This makes platforms with such xHCI controllers unavailable during initrd, and unable to boot from a USB drive. There are SuperSpeed ports routed through such controller on some platforms, too, which also renders the USB keyboard and mouse unusable.

Here's a snippet of the kernel log from such platform, showing a keyboard and a mouse being detected only after the initrd switched root:
```
[    9.352608] systemd-journald[187]: Received SIGTERM from PID 1 (systemd).
[    9.500146] systemd[1]: systemd 257.2 running in system mode (OMITTED)
...
[   11.187756] xhci-pci-renesas 0000:04:00.0: xHCI Host Controller
[   11.187870] xhci-pci-renesas 0000:04:00.0: new USB bus registered, assigned bus number 7
[   11.193261] xhci-pci-renesas 0000:04:00.0: hcc params 0x014051cf hci version 0x100 quirks 0x0000000100000010
[   11.194806] xhci-pci-renesas 0000:04:00.0: xHCI Host Controller
[   11.196601] xhci-pci-renesas 0000:04:00.0: new USB bus registered, assigned bus number 8
[   11.196613] xhci-pci-renesas 0000:04:00.0: Host supports USB 3.0 SuperSpeed
[   11.196927] usb usb7: New USB device found, idVendor=1d6b, idProduct=0002, bcdDevice= 6.13
[   11.196931] usb usb7: New USB device strings: Mfr=3, Product=2, SerialNumber=1
[   11.196935] usb usb7: Product: xHCI Host Controller
[   11.196938] usb usb7: Manufacturer: Linux 6.13.3-aosc-main xhci-hcd
[   11.196941] usb usb7: SerialNumber: 0000:04:00.0
[   11.199598] hub 7-0:1.0: USB hub found
[   11.199630] hub 7-0:1.0: 4 ports detected
...
[   11.439561] usb 7-2: new high-speed USB device number 2 using xhci-pci-renesas
[   11.568361] usb 7-2: New USB device found, idVendor=1532, idProduct=0114, bcdDevice= 1.00
[   11.568369] usb 7-2: New USB device strings: Mfr=1, Product=2, SerialNumber=0
[   11.568372] usb 7-2: Product: DeathStalker Ultimate
[   11.568376] usb 7-2: Manufacturer: Razer
[   11.600474] input: Razer DeathStalker Ultimate as /devices/pci0000:00/0000:00:0e.0/0000:04:00.0/usb7/7-2/7-2:1.0/0003:1532:0114.0001/input/input12
[   11.600686] hid-generic 0003:1532:0114.0001: input,hidraw0: USB HID v1.11 Mouse [Razer DeathStalker Ultimate] on usb-0000:04:00.0-2/input0
[   11.601137] input: Razer DeathStalker Ultimate Keyboard as /devices/pci0000:00/0000:00:0e.0/0000:04:00.0/usb7/7-2/7-2:1.1/0003:1532:0114.0002/input/input13
[   11.652148] input: Razer DeathStalker Ultimate as /devices/pci0000:00/0000:00:0e.0/0000:04:00.0/usb7/7-2/7-2:1.1/0003:1532:0114.0002/input/input14
[   11.652409] hid-generic 0003:1532:0114.0002: input,hidraw1: USB HID v1.11 Keyboard [Razer DeathStalker Ultimate] on usb-0000:04:00.0-2/input1
[   11.653054] input: Razer DeathStalker Ultimate as /devices/pci0000:00/0000:00:0e.0/0000:04:00.0/usb7/7-2/7-2:1.2/0003:1532:0114.0003/input/input15
[   11.703768] hid-generic 0003:1532:0114.0003: input,hidraw2: USB HID v1.11 Keyboard [Razer DeathStalker Ultimate] on usb-0000:04:00.0-2/input2
```

(cherry picked from commit https://github.com/dracut-ng/dracut-ng/commit/20cc20d2ac9c2908da6735b04dba49c1cb1b0bab)