### PR TITLE
fix(90kernel-modules): explicitly include xhci-pci-renesas (bsc#1238258) (SLFO)

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -38,12 +38,15 @@ installkernel() {
         hostonly='' instmods \
             hid_generic unix
 
+        # xhci-pci-renesas is needed for the USB to be available during
+        # initrd on platforms with such USB controllers since Linux
+        # 6.12-rc1 (commit 25f51b76f90f).
         hostonly=$(optional_hostonly) instmods \
             ehci-hcd ehci-pci ehci-platform \
             ohci-hcd ohci-pci \
             uhci-hcd \
             usbhid \
-            xhci-hcd xhci-pci xhci-plat-hcd \
+            xhci-hcd xhci-pci xhci-pci-renesas xhci-plat-hcd \
             "=drivers/hid" \
             "=drivers/tty/serial" \
             "=drivers/input/serio" \

--- a/suse/README.susemaint
+++ b/suse/README.susemaint
@@ -393,3 +393,4 @@ c79fc8fd fix(dracut): rework timeout for devices added via --mount and --add-dev
 93df9ad2 feat(livenet): get live image size from TFTP servers
 cc2c48a0 fix(iscsi): don't require network setup for bnx2i
 f30cf46e fix(iscsi): attempt iSCSI login before all interfaces are up
+20cc20d2 fix(90kernel-modules): explicitly include xhci-pci-renesas


### PR DESCRIPTION
#406 for SLFO