### PR TITLE
fix(crypt): always install s390 crypto modules (jsc#IBM-1444)

### DIFF
--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -47,7 +47,13 @@ depends() {
 
 # called by dracut
 installkernel() {
-    hostonly="" instmods drbg dm_crypt
+    local _arch=${DRACUT_ARCH:-$(uname -m)}
+    local _s390drivers=
+    if [[ $_arch == "s390" ]] || [[ $_arch == "s390x" ]]; then
+        _s390drivers="=drivers/s390/crypto"
+    fi
+
+    hostonly="" instmods drbg dm_crypt ${_s390drivers:+"$_s390drivers"}
 
     # in case some of the crypto modules moved from compiled in
     # to module based, try to install those modules

--- a/modules.d/90crypt/module-setup.sh
+++ b/modules.d/90crypt/module-setup.sh
@@ -47,8 +47,7 @@ depends() {
 
 # called by dracut
 installkernel() {
-    hostonly="" instmods drbg
-    instmods dm_crypt
+    hostonly="" instmods drbg dm_crypt
 
     # in case some of the crypto modules moved from compiled in
     # to module based, try to install those modules

--- a/suse/README.susemaint
+++ b/suse/README.susemaint
@@ -409,3 +409,4 @@ f3fffa1e fix(systemd-veritysetup): install dm-verity kernel module
 6ac1033c feat(dmsquash-live): add support for rd.live.overlay.nouserconfirmprompt
 9b12ef98 feat(lsinitrd.sh): enable unpacking files from squash-root.img
 d10455ad feat(lsinitrd.sh): print stored dracut cmdline
+59af2fff fix(crypt): install dm_crypt module in non-hostonly mode as well


### PR DESCRIPTION
Not only are the specific encryption modules not being installed on s390/s390x in non-hostonly mode, but also it's failing the detection of the kernel modules needed to decrypt PAES-encrypted volumes in hostonly mode via dmsetup. So,
since the increase in size is not that much (~ 150K), always add all the drivers under s390/crypto in this architecture.
