### PR TITLE
fix(dmsquash-live): do not check ISO md5 if image filesystem (bsc#1240919)

### DIFF
--- a/modules.d/90dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/90dmsquash-live/dmsquash-live-root.sh
@@ -60,27 +60,32 @@ get_check_dev() {
     echo "$_udevinfo" | grep "DEVNAME=" | sed 's/DEVNAME=//'
 }
 
-# Find the right device to run check on
-check_dev=$(get_check_dev "$livedev")
-# CD/DVD media check
-[ -b "$check_dev" ] && fs=$(det_fs "$check_dev")
-if [ "$fs" = "iso9660" -o "$fs" = "udf" ]; then
-    check="yes"
-fi
-getarg rd.live.check -d check || check=""
-if [ -n "$check" ]; then
-    type plymouth > /dev/null 2>&1 && plymouth --hide-splash
-    if [ -n "$DRACUT_SYSTEMD" ]; then
-        p=$(dev_unit_name "$check_dev")
-        systemctl start checkisomd5@"${p}".service
-    else
-        checkisomd5 --verbose "$check_dev"
+# Check ISO checksum only if we have a path to a block device (or just its name
+# without '/dev'). In other words, in this context, we perform the check only
+# if the given $livedev is not a filesystem file image.
+if [ ! -f "$livedev" ]; then
+    # Find the right device to run check on
+    check_dev=$(get_check_dev "$livedev")
+    # CD/DVD media check
+    [ -b "$check_dev" ] && fs=$(det_fs "$check_dev")
+    if [ "$fs" = "iso9660" -o "$fs" = "udf" ]; then
+        check="yes"
     fi
-    if [ $? -eq 1 ]; then
-        die "CD check failed!"
-        exit 1
+    getarg rd.live.check -d check || check=""
+    if [ -n "$check" ]; then
+        type plymouth > /dev/null 2>&1 && plymouth --hide-splash
+        if [ -n "$DRACUT_SYSTEMD" ]; then
+            p=$(dev_unit_name "$check_dev")
+            systemctl start checkisomd5@"${p}".service
+        else
+            checkisomd5 --verbose "$check_dev"
+        fi
+        if [ $? -eq 1 ]; then
+            die "CD check failed!"
+            exit 1
+        fi
+        type plymouth > /dev/null 2>&1 && plymouth --show-splash
     fi
-    type plymouth > /dev/null 2>&1 && plymouth --show-splash
 fi
 
 ln -s "$livedev" /run/initramfs/livedev

--- a/modules.d/90dmsquash-live/dmsquash-live-root.sh
+++ b/modules.d/90dmsquash-live/dmsquash-live-root.sh
@@ -110,7 +110,7 @@ if [ -f "$livedev" ]; then
         auto) die "cannot mount live image (unknown filesystem type)" ;;
         *) FSIMG=$livedev ;;
     esac
-    [ -e /sys/fs/"$fstype" ] || modprobe "$fstype"
+    load_fstype "$fstype"
 else
     livedev_fstype=$(det_fs "$livedev")
     if [ "$livedev_fstype" = "squashfs" ]; then

--- a/suse/README.susemaint
+++ b/suse/README.susemaint
@@ -410,3 +410,5 @@ f3fffa1e fix(systemd-veritysetup): install dm-verity kernel module
 9b12ef98 feat(lsinitrd.sh): enable unpacking files from squash-root.img
 d10455ad feat(lsinitrd.sh): print stored dracut cmdline
 59af2fff fix(crypt): install dm_crypt module in non-hostonly mode as well
+541ae946 fix(dmsquash-live): use load_fstype to load driver for filesystems
+c6906fea fix(dmsquash-live): do not check ISO md5 if image filesystem


### PR DESCRIPTION
The ISO checksum code was executed independently of the provided `$livedev`. Often, this is a loop device pointing to an ISO image, but in other cases `dmsquash-live-root` receives the path to a filesystem image. In this case, we can't use `udevadm` to extract information because it is not a device, and trying to do that leads to `udevadm` error messages (but not blocking).

Therefore, the ISO checksum check must be performed only if the provided `$livedev` is **not** a regular file.

Signed-off-by: Federico Vaga <federico.vaga@cern.ch>
(cherry picked from commit https://github.com/dracut-ng/dracut-ng/commit/c6906fea4df28428aa889c7bb8197689ae8107ee)
