### PR TITLE
fix(dracut-functions): allow for \ in get_maj_min file path

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -244,7 +244,7 @@ get_maj_min() {
     local _out
 
     if [[ $get_maj_min_cache_file ]]; then
-        _out="$(grep -m1 -oE "^$1 \S+$" "$get_maj_min_cache_file" | awk '{print $NF}')"
+        _out="$(grep -m1 -oE "^${1//\\/\\\\} \S+$" "$get_maj_min_cache_file" | awk '{print $NF}')"
     fi
 
     if ! [[ "$_out" ]]; then


### PR DESCRIPTION
as the path might be f.e. /dev/disk/by-partlabel/EFI\x20System\x20Partition which would produce Warning 'grep: warning: stray \ before x' in get_maj_min

See https://github.com/pvalena/dracut-ng/commit/43b3bcb3656d774e7e3fd00fa4ce890b32625e4b

And:

https://cgit.git.savannah.gnu.org/cgit/grep.git/commit/?id=e7f8e8eb1fd41b308ee10741bbd8068acc1847c2

I noticed these grep warning because on my system:

```
~> ls /dev/disk/by-partlabel
'Basic\x20data\x20partition'@  'EFI\x20system\x20partition'@  'Microsoft\x20reserved\x20partition'@
```

## Checklist
- [X ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it


