### PR TITLE
fix(74nvmf): set root=nvmf

### DIFF
--- a/modules.d/95nvmf/parse-nvmf-boot-connections.sh
+++ b/modules.d/95nvmf/parse-nvmf-boot-connections.sh
@@ -324,3 +324,7 @@ fi
 
 /sbin/initqueue --settled --onetime --name nvmf-connect-settled /sbin/nvmf-autoconnect.sh settled
 /sbin/initqueue --timeout --onetime --name nvmf-connect-timeout /sbin/nvmf-autoconnect.sh timeout
+
+# shellcheck disable=SC2034
+rootok=1
+[ -z "$root" ] && root="nvmf"


### PR DESCRIPTION
In a restricted image like kdump the kernel commandline argument root= is typically absent. However it is required by the 45net-lib/netroot.sh module that fails with:

    [   23.599862] dracut: FATAL: No or empty root= argument
    [   23.604956] dracut: Refusing to continue

Inspired by the 74iscsi module, let's set it to root=nvmf if not set before.

## Checklist
- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Upstream: dracut-ng/dracut-ng#1370
Fixes: bsc#1238848