### PR TITLE
Fix PXE boot with filled-in NBFT (bsc#1238848)

### DIFF
--- a/modules.d/95nvmf/nvmf-autoconnect.sh
+++ b/modules.d/95nvmf/nvmf-autoconnect.sh
@@ -6,6 +6,8 @@
 
 [ "$RD_DEBUG" != yes ] || set -x
 
+trap 'echo ok >/tmp/nvmf.done' 0
+
 if [ "$1" = timeout ]; then
     [ ! -f /sys/class/fc/fc_udev_device/nvme_discovery ] \
         || echo add > /sys/class/fc/fc_udev_device/nvme_discovery

--- a/modules.d/95nvmf/parse-nvmf-boot-connections.sh
+++ b/modules.d/95nvmf/parse-nvmf-boot-connections.sh
@@ -324,6 +324,8 @@ fi
 
 /sbin/initqueue --settled --onetime --name nvmf-connect-settled /sbin/nvmf-autoconnect.sh settled
 /sbin/initqueue --timeout --onetime --name nvmf-connect-timeout /sbin/nvmf-autoconnect.sh timeout
+# Make sure the autoconnect script is run at least once
+echo '[ -f /tmp/nvmf.done ]' >"$hookdir/initqueue/finished/95-nvmf.sh"
 
 # shellcheck disable=SC2034
 rootok=1

--- a/modules.d/95nvmf/parse-nvmf-boot-connections.sh
+++ b/modules.d/95nvmf/parse-nvmf-boot-connections.sh
@@ -318,7 +318,7 @@ if [ -e /tmp/nvmf_needs_network ] || [ -e /tmp/valid_nbft_entry_found ]; then
     echo "rd.neednet=1" > /etc/cmdline.d/nvmf-neednet.conf
     # netroot is a global variable that is present in all "sourced" scripts
     # shellcheck disable=SC2034
-    netroot=nbft
+    [ "$netroot" ] || netroot=nbft
     rm -f /tmp/nvmf_needs_network
 fi
 


### PR DESCRIPTION
## Changes

This PR fixes installing SLE16 over PXE. See [bsc#1238848](https://bugzilla.suse.com/show_bug.cgi?id=1238848).

## Checklist
- [x] I have tested it locally

