### PR TITLE
fix(lsinitrd, dracut-initramfs-restore): detect initrd for BLS Type #1 entries (bsc#1248271)

### DIFF
--- a/dracut-initramfs-restore.sh
+++ b/dracut-initramfs-restore.sh
@@ -28,26 +28,49 @@ fi
 
 mount -o ro /boot &> /dev/null || true
 
-if [[ -d /efi/loader/entries || -L /efi/loader/entries ]] \
-    && [[ -d /efi/$MACHINE_ID || -L /efi/$MACHINE_ID ]]; then
-    IMG="/efi/${MACHINE_ID}/${KERNEL_VERSION}/initrd"
-elif [[ -d /boot/loader/entries || -L /boot/loader/entries ]] \
-    && [[ -d /boot/$MACHINE_ID || -L /boot/$MACHINE_ID ]]; then
-    IMG="/boot/${MACHINE_ID}/${KERNEL_VERSION}/initrd"
-elif [[ -d /boot/efi/loader/entries || -L /boot/efi/loader/entries ]] \
-    && [[ -d /boot/efi/$MACHINE_ID || -L /boot/efi/$MACHINE_ID ]]; then
-    IMG="/boot/efi/$MACHINE_ID/$KERNEL_VERSION/initrd"
-elif [[ -f /lib/modules/${KERNEL_VERSION}/initrd ]]; then
-    IMG="/lib/modules/${KERNEL_VERSION}/initrd"
-elif [[ -f /boot/initrd-${KERNEL_VERSION} ]]; then
-    IMG="/boot/initrd-${KERNEL_VERSION}"
-elif mountpoint -q /efi; then
-    IMG="/efi/$MACHINE_ID/$KERNEL_VERSION/initrd"
-elif mountpoint -q /boot/efi; then
-    IMG="/boot/efi/$MACHINE_ID/$KERNEL_VERSION/initrd"
-else
-    echo "No initramfs image found to restore!"
-    exit 1
+if command -v bootctl > /dev/null && command -v jq > /dev/null; then
+    # get proper path to $BOOT
+    base_path=$(bootctl -x)
+    # get initrd key of the selected bootloader entry (i.e., the one that
+    # is actually used to boot the system)
+    mapfile -t files < <(bootctl --json=pretty list 2> /dev/null | jq -r '.[] | select(.isSelected).initrd[]' 2> /dev/null)
+    if [[ ${#files[@]} -ge 1 ]] && [[ -e "${base_path}${files[0]}" ]]; then
+        IMG="${base_path}${files[0]}"
+    else
+        # if the selected bootloader entry does not have any initrd keys, check
+        # the default (maybe the current selected entry was removed)
+        # also check at least that the default bootloader entry has the same
+        # kernel version
+        mapfile -t files < <(bootctl --json=pretty list 2> /dev/null | jq -r '.[] | select(.isDefault).initrd[]' 2> /dev/null)
+        if [[ ${#files[@]} -ge 1 ]] && [[ -e "${base_path}${files[0]}" ]] \
+            && [[ ${files[0]} == *"${kernel_version}"* ]]; then
+            IMG="${base_path}${files[0]}"
+        fi
+    fi
+fi
+
+if [[ -z $IMG ]]; then
+    if [[ -d /efi/loader/entries || -L /efi/loader/entries ]] \
+        && [[ -d /efi/$MACHINE_ID || -L /efi/$MACHINE_ID ]]; then
+        IMG="/efi/${MACHINE_ID}/${KERNEL_VERSION}/initrd"
+    elif [[ -d /boot/loader/entries || -L /boot/loader/entries ]] \
+        && [[ -d /boot/$MACHINE_ID || -L /boot/$MACHINE_ID ]]; then
+        IMG="/boot/${MACHINE_ID}/${KERNEL_VERSION}/initrd"
+    elif [[ -d /boot/efi/loader/entries || -L /boot/efi/loader/entries ]] \
+        && [[ -d /boot/efi/$MACHINE_ID || -L /boot/efi/$MACHINE_ID ]]; then
+        IMG="/boot/efi/$MACHINE_ID/$KERNEL_VERSION/initrd"
+    elif [[ -f /lib/modules/${KERNEL_VERSION}/initrd ]]; then
+        IMG="/lib/modules/${KERNEL_VERSION}/initrd"
+    elif [[ -f /boot/initrd-${KERNEL_VERSION} ]]; then
+        IMG="/boot/initrd-${KERNEL_VERSION}"
+    elif mountpoint -q /efi; then
+        IMG="/efi/$MACHINE_ID/$KERNEL_VERSION/initrd"
+    elif mountpoint -q /boot/efi; then
+        IMG="/boot/efi/$MACHINE_ID/$KERNEL_VERSION/initrd"
+    else
+        echo "No initramfs image found to restore!"
+        exit 1
+    fi
 fi
 
 cd /run/initramfs

--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -109,39 +109,59 @@ if [[ $1 ]]; then
         exit 1
     fi
 else
-    if [[ -d /efi/Default ]] || [[ -d /boot/Default ]] || [[ -d /boot/efi/Default ]]; then
-        MACHINE_ID="Default"
-    elif [[ -s /etc/machine-id ]]; then
-        read -r MACHINE_ID < /etc/machine-id
-        [[ $MACHINE_ID == "uninitialized" ]] && MACHINE_ID="Default"
-    else
-        MACHINE_ID="Default"
+    if command -v bootctl > /dev/null && command -v jq > /dev/null; then
+        # get proper path to $BOOT
+        base_path=$(bootctl -x)
+        # get initrd key of the selected bootloader entry (i.e., the one that
+        # is actually used to boot the system)
+        mapfile -t files < <(bootctl --json=pretty list 2> /dev/null | jq -r '.[] | select(.isSelected).initrd[]' 2> /dev/null)
+        if [[ ${#files[@]} -ge 1 ]] && [[ -e "${base_path}${files[0]}" ]]; then
+            image="${base_path}${files[0]}"
+        else
+            # if the selected bootloader entry does not have any initrd keys, check
+            # the default (maybe the current selected entry was removed)
+            mapfile -t files < <(bootctl --json=pretty list 2> /dev/null | jq -r '.[] | select(.isDefault).initrd[]' 2> /dev/null)
+            if [[ ${#files[@]} -ge 1 ]] && [[ -e "${base_path}${files[0]}" ]]; then
+                image="${base_path}${files[0]}"
+            fi
+        fi
     fi
 
-    if [[ -d /efi/loader/entries || -L /efi/loader/entries ]] \
-        && [[ $MACHINE_ID ]] \
-        && [[ -d /efi/${MACHINE_ID} || -L /efi/${MACHINE_ID} ]]; then
-        image="/efi/${MACHINE_ID}/${KERNEL_VERSION}/initrd"
-    elif [[ -d /boot/loader/entries || -L /boot/loader/entries ]] \
-        && [[ $MACHINE_ID ]] \
-        && [[ -d /boot/${MACHINE_ID} || -L /boot/${MACHINE_ID} ]]; then
-        image="/boot/${MACHINE_ID}/${KERNEL_VERSION}/initrd"
-    elif [[ -d /boot/efi/loader/entries || -L /boot/efi/loader/entries ]] \
-        && [[ $MACHINE_ID ]] \
-        && [[ -d /boot/efi/${MACHINE_ID} || -L /boot/efi/${MACHINE_ID} ]]; then
-        image="/boot/efi/${MACHINE_ID}/${KERNEL_VERSION}/initrd"
-    elif [[ -f /lib/modules/${KERNEL_VERSION}/initrd ]]; then
-        image="/lib/modules/${KERNEL_VERSION}/initrd"
-    elif [[ -f /boot/initrd-${KERNEL_VERSION} ]]; then
-        image="/boot/initrd-${KERNEL_VERSION}"
-    elif [[ $MACHINE_ID ]] \
-        && mountpoint -q /efi; then
-        image="/efi/${MACHINE_ID}/${KERNEL_VERSION}/initrd"
-    elif [[ $MACHINE_ID ]] \
-        && mountpoint -q /boot/efi; then
-        image="/boot/efi/${MACHINE_ID}/${KERNEL_VERSION}/initrd"
-    else
-        image=""
+    if [[ -z $image ]]; then
+        if [[ -d /efi/Default ]] || [[ -d /boot/Default ]] || [[ -d /boot/efi/Default ]]; then
+            MACHINE_ID="Default"
+        elif [[ -s /etc/machine-id ]]; then
+            read -r MACHINE_ID < /etc/machine-id
+            [[ $MACHINE_ID == "uninitialized" ]] && MACHINE_ID="Default"
+        else
+            MACHINE_ID="Default"
+        fi
+
+        if [[ -d /efi/loader/entries || -L /efi/loader/entries ]] \
+            && [[ $MACHINE_ID ]] \
+            && [[ -d /efi/${MACHINE_ID} || -L /efi/${MACHINE_ID} ]]; then
+            image="/efi/${MACHINE_ID}/${KERNEL_VERSION}/initrd"
+        elif [[ -d /boot/loader/entries || -L /boot/loader/entries ]] \
+            && [[ $MACHINE_ID ]] \
+            && [[ -d /boot/${MACHINE_ID} || -L /boot/${MACHINE_ID} ]]; then
+            image="/boot/${MACHINE_ID}/${KERNEL_VERSION}/initrd"
+        elif [[ -d /boot/efi/loader/entries || -L /boot/efi/loader/entries ]] \
+            && [[ $MACHINE_ID ]] \
+            && [[ -d /boot/efi/${MACHINE_ID} || -L /boot/efi/${MACHINE_ID} ]]; then
+            image="/boot/efi/${MACHINE_ID}/${KERNEL_VERSION}/initrd"
+        elif [[ -f /lib/modules/${KERNEL_VERSION}/initrd ]]; then
+            image="/lib/modules/${KERNEL_VERSION}/initrd"
+        elif [[ -f /boot/initrd-${KERNEL_VERSION} ]]; then
+            image="/boot/initrd-${KERNEL_VERSION}"
+        elif [[ $MACHINE_ID ]] \
+            && mountpoint -q /efi; then
+            image="/efi/${MACHINE_ID}/${KERNEL_VERSION}/initrd"
+        elif [[ $MACHINE_ID ]] \
+            && mountpoint -q /boot/efi; then
+            image="/boot/efi/${MACHINE_ID}/${KERNEL_VERSION}/initrd"
+        else
+            image=""
+        fi
     fi
 fi
 

--- a/suse/dracut.spec
+++ b/suse/dracut.spec
@@ -69,7 +69,7 @@ Conflicts:      btrfsprogs < 3.18
 # suse-module-tools >= 15.4.7 is prepared for the removal of mkinitrd-suse.sh
 Conflicts:      suse-module-tools < 15.4.7
 %{?systemd_requires}
-Requires:       (jq if nvme-cli)
+Requires:       (jq if (nvme-cli or systemd-boot or grub2-x86_64-efi-bls))
 
 %description
 Dracut contains tools to create a bootable initramfs for Linux kernels >= 2.6.


### PR DESCRIPTION
dracut is making wrong assumptions with BLS Type #1 entries.

- The ESP is not always used to store boot loader entries, there may be also an Extended Boot Loader Partition (XBOOTLDR). The spec defines the concept of the `$BOOT` partition placeholder, as the primary place to put boot menu entry resources into.

- The `machine-id` is not always used as subdirectory, it can be the `entry-token`.

- Also, although the name "initrd" is referenced in the examples, its use is not mandatory. E.g., in openSUSE we add a suffix with its hash value.

Manually implementing this autodetection logic can be complex, but all the necessary information is provided by `bootctl`, so use it if available.

More info: https://uapi-group.org/specifications/specs/boot_loader_specification

Context adjusted from upstream PR: https://github.com/dracut-ng/dracut-ng/pull/1596