### PR TITLE
fix(systemd): install new dlopened libraries

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -268,10 +268,17 @@ EOF
     # Install library file(s)
     _arch=${DRACUT_ARCH:-$(uname -m)}
     inst_libdir_file \
-        {"tls/$_arch/",tls/,"$_arch/",}"libgcrypt.so*" \
+        {"tls/$_arch/",tls/,"$_arch/",}"libacl.so*" \
+        {"tls/$_arch/",tls/,"$_arch/",}"libaudit.so*" \
+        {"tls/$_arch/",tls/,"$_arch/",}"libblkid.so*" \
         {"tls/$_arch/",tls/,"$_arch/",}"libbpf.so*" \
+        {"tls/$_arch/",tls/,"$_arch/",}"libgcrypt.so*" \
         {"tls/$_arch/",tls/,"$_arch/",}"libkmod.so*" \
+        {"tls/$_arch/",tls/,"$_arch/",}"libmount.so*" \
         {"tls/$_arch/",tls/,"$_arch/",}"libnss_*" \
+        {"tls/$_arch/",tls/,"$_arch/",}"libpam.so*" \
+        {"tls/$_arch/",tls/,"$_arch/",}"libseccomp.so*" \
+        {"tls/$_arch/",tls/,"$_arch/",}"libselinux.so*" \
         {"tls/$_arch/",tls/,"$_arch/",}"systemd/libsystemd*.so"
 
 }


### PR DESCRIPTION
Preparation for systemd-v259. In chronological order:

- libaudit: https://github.com/systemd/systemd/commit/4d8c5c657ae0829f93944a00302e7ce700913e54
- libpam: https://github.com/systemd/systemd/commit/882c9ce0402ec6e37201628a9a361500ff39b1ed
- libacl: https://github.com/systemd/systemd/commit/7c3a7f925f83bd05a49e8b1f09726cccc26977f7
- libblkid: https://github.com/systemd/systemd/commit/c349edfe49dc2c4b8a79e5d08ecf7c8e93c4c909
- libseccomp: https://github.com/systemd/systemd/commit/aaca6bd5d97258f29c1b8c991e8617c7272308e0
- libmount: https://github.com/systemd/systemd/commit/b3243f4beead231e27a4f017f53288a303177cb2
- libselinux: https://github.com/systemd/systemd/commit/83b6ef9b62765b11bc602eae906ff13a5464a638