### PR TITLE
Fix and update testsuite (bsc#1254873)

### DIFF
--- a/modules.d/80test/module-setup.sh
+++ b/modules.d/80test/module-setup.sh
@@ -9,6 +9,13 @@ depends() {
     echo "debug"
 }
 
+installkernel() {
+    instmods \
+        sd_mod \
+        virtio_pci \
+        virtio_scsi
+}
+
 install() {
     inst poweroff
     inst_hook shutdown-emergency 000 "$moddir/hard-off.sh"

--- a/modules.d/95udev-rules/module-setup.sh
+++ b/modules.d/95udev-rules/module-setup.sh
@@ -87,6 +87,10 @@ install() {
 
     inst_multiple -o /etc/pcmcia/config.opts
 
-    inst_libdir_file "libnss_files*"
+    # Install required libraries.
+    _arch=${DRACUT_ARCH:-$(uname -m)}
+    inst_libdir_file \
+        {"tls/$_arch/",tls/,"$_arch/",}"libkmod.so*" \
+        {"tls/$_arch/",tls/,"$_arch/",}"libnss_files*"
 
 }

--- a/suse/README.susemaint
+++ b/suse/README.susemaint
@@ -137,7 +137,7 @@ MERGED  b2c6b584 fix(dracut.sh): exit if resolving executable dependencies fails
         d55fa823 ci: migrate from systemd-boot to systemd-utils in Gentoo container
         403f4e8e ci: do not run test container generation on forked repos by default
 MERGED  16855765 refactor(install): log about missing firmware only once
-        c46513fb test: increase test VM memory from 512M to 1024M to avoid OOM killer
+MERGED  c46513fb test: increase test VM memory from 512M to 1024M to avoid OOM killer
 MERGED  a804945f fix(integrity): do not require ls
         e278a965 ci: match comment with code
         9e1e9245 ci: automate release generation
@@ -202,7 +202,7 @@ MERGED  afb5717e fix(kernel-modules): add interconnect drivers
         d244b316 test(LVM-THIN): avoid thin pool size warning
         739b9e1b ci: cleanup containers
         ae7cd94b test: add empty default test_cleanup implementation
-        f1346763 test: move more common test code to test-functions
+MERGED  f1346763 test: move more common test code to test-functions
         5ac581ef fix(resolve-deps): check the existing file—not the source
 MERGED  07af8d58 fix(dracut-lib.sh): remove successful finished initqueue scripts
 MERGED  7310a641 fix(udev-rules): remove firmware.rules
@@ -213,7 +213,7 @@ MERGED  07b49a3e fix(virtiofs): add virtio_pci kernel module to virtiofs
         c08ae406 ci: install multipath-tools into openSuse container
         d1187543 test: remove references of dhcpd3 from tests
         1843c16c test: move test condition to test_check
-        006890a2 test: upgrade to ext4
+MERGED  006890a2 test: upgrade to ext4
 MERGED  86c8a5a7 fix(dracut-systemd): rootfs-generator cannot write outside of generator dir
 MERGED  acfa793b fix(dracut-systemd): check and create generator dir outside of inner function
 MERGED  a7c04716 fix(dracut-systemd): do not hardcode the systemd generator directory
@@ -441,3 +441,10 @@ f879b04d fix(74nvmf): make sure autoconnect script is run at least once
 89dcdd91 fix(dracut.sh): check that custom fw search patch exists before reading it
 46369b3b fix(dmsquash-live): install required stat binary
 de8b63f5 fix(multipath): add udev rule 99-z-dm-mpath-late.rules
+540638494 test: switch to virtio for the QEMU drive
+92441b6f1 test: switch to virtio for the QEMU drive
+f78df96b9 fix(systemd): move installation of libkmod to udev-rules module
+b6e08825b test: make the size of all test drives 512 MB
+f29d49d68 test(FULL SYSTEMD): no need to include dbus to the target rootfs
+033710300 test(FULL-SYSTEMD): use poweroff to shut down test
+0d2dcd12d test: move /failed to /run/failed as rootfs might be read-only

--- a/test/TEST-01-BASIC/create-root.sh
+++ b/test/TEST-01-BASIC/create-root.sh
@@ -12,11 +12,11 @@ udevadm settle
 
 set -ex
 
-mkfs.ext4 -L '  rdinit=/bin/sh' /dev/disk/by-id/ata-disk_root
+mkfs.ext4 -L '  rdinit=/bin/sh' /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root
 mkdir -p /root
-mount -t ext4 /dev/disk/by-id/ata-disk_root /root
+mount -t ext4 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root /root
 cp -a -t /root /source/*
 mkdir -p /root/run
 umount /root
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-01-BASIC/create-root.sh
+++ b/test/TEST-01-BASIC/create-root.sh
@@ -12,9 +12,9 @@ udevadm settle
 
 set -ex
 
-mkfs.ext3 -L '  rdinit=/bin/sh' /dev/disk/by-id/ata-disk_root
+mkfs.ext4 -L '  rdinit=/bin/sh' /dev/disk/by-id/ata-disk_root
 mkdir -p /root
-mount /dev/disk/by-id/ata-disk_root /root
+mount -t ext4 /dev/disk/by-id/ata-disk_root /root
 cp -a -t /root /source/*
 mkdir -p /root/run
 umount /root

--- a/test/TEST-01-BASIC/test-init.sh
+++ b/test/TEST-01-BASIC/test-init.sh
@@ -7,7 +7,7 @@ export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 command -v plymouth > /dev/null 2>&1 && plymouth --quit
 exec > /dev/console 2>&1
 
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 
 export TERM=linux
 export PS1='initramfs-test:\w\$ '

--- a/test/TEST-01-BASIC/test.sh
+++ b/test/TEST-01-BASIC/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # shellcheck disable=SC2034
-TEST_DESCRIPTION="root filesystem on a ext3 filesystem"
+TEST_DESCRIPTION="root filesystem on a ext4 filesystem"
 
 KVERSION=${KVERSION-$(uname -r)}
 
@@ -40,8 +40,8 @@ test_setup() {
     # devices, volume groups, encrypted partitions, etc.
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -m "test-makeroot dash rootfs-block kernel-modules" \
-        -d "piix ide-gd_mod ata_piix ext3 sd_mod" \
-        -I "mkfs.ext3" \
+        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
+        -I "mkfs.ext4" \
         -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
         --nomdadmconf \
         --no-hostonly-cmdline -N \
@@ -58,7 +58,7 @@ test_setup() {
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "root=/dev/dracut/root rw rootfstype=ext3 quiet console=ttyS0,115200n81 selinux=0" \
+        -append "root=/dev/dracut/root rw rootfstype=ext4 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd "$TESTDIR"/initramfs.makeroot || return 1
     grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/marker.img || return 1
     rm -- "$TESTDIR"/marker.img
@@ -66,7 +66,7 @@ test_setup() {
     # make sure --omit-drivers does not filter out drivers using regexp to test for an earlier regression (assuming there is no one letter linux kernel module needed to run the test)
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -a "test watchdog" \
-        -d "piix ide-gd_mod ata_piix ext3 sd_mod i6300esb ib700wdt" \
+        -d "piix ide-gd_mod ata_piix ext4 sd_mod i6300esb ib700wdt" \
         --omit-drivers 'a b c d e f g h i j k l m n o p q r s t u v w x y z' \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1

--- a/test/TEST-01-BASIC/test.sh
+++ b/test/TEST-01-BASIC/test.sh
@@ -49,7 +49,7 @@ test_setup() {
     declare -a disk_args=()
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root 80
+    qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root 1
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \

--- a/test/TEST-01-BASIC/test.sh
+++ b/test/TEST-01-BASIC/test.sh
@@ -8,8 +8,8 @@ TEST_DESCRIPTION="root filesystem on a ext4 filesystem"
 test_run() {
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/root.img root
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root
 
     test_marker_reset
     "$testdir"/run-qemu \
@@ -48,13 +48,13 @@ test_setup() {
 
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/root.img root 80
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root 80
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "root=/dev/dracut/root rw rootfstype=ext4 quiet console=ttyS0,115200n81 selinux=0" \
+        -append "root=/dev/dracut/root rw rootfstype=ext4 console=ttyS0,115200n81 selinux=0" \
         -initrd "$TESTDIR"/initramfs.makeroot || return 1
     test_marker_check dracut-root-block-created || return 1
     rm -- "$TESTDIR"/marker.img
@@ -62,7 +62,7 @@ test_setup() {
     # make sure --omit-drivers does not filter out drivers using regexp to test for an earlier regression (assuming there is no one letter linux kernel module needed to run the test)
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -a "test watchdog" \
-        -d "piix ide-gd_mod ata_piix ext4 sd_mod i6300esb ib700wdt" \
+        -d "piix ide-gd_mod ata_piix ext4 i6300esb ib700wdt" \
         --omit-drivers 'a b c d e f g h i j k l m n o p q r s t u v w x y z' \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1

--- a/test/TEST-02-SYSTEMD/create-root.sh
+++ b/test/TEST-02-SYSTEMD/create-root.sh
@@ -11,11 +11,11 @@ udevadm control --reload
 set -e
 
 udevadm settle
-mkfs.ext4 -L dracut /dev/disk/by-id/ata-disk_root
+mkfs.ext4 -L dracut /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root
 mkdir -p /root
-mount -t ext4 /dev/disk/by-id/ata-disk_root /root
+mount -t ext4 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root /root
 cp -a -t /root /source/*
 mkdir -p /root/run
 umount /root
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-02-SYSTEMD/create-root.sh
+++ b/test/TEST-02-SYSTEMD/create-root.sh
@@ -11,9 +11,9 @@ udevadm control --reload
 set -e
 
 udevadm settle
-mkfs.ext3 -L dracut /dev/disk/by-id/ata-disk_root
+mkfs.ext4 -L dracut /dev/disk/by-id/ata-disk_root
 mkdir -p /root
-mount /dev/disk/by-id/ata-disk_root /root
+mount -t ext4 /dev/disk/by-id/ata-disk_root /root
 cp -a -t /root /source/*
 mkdir -p /root/run
 umount /root

--- a/test/TEST-02-SYSTEMD/test-init.sh
+++ b/test/TEST-02-SYSTEMD/test-init.sh
@@ -7,7 +7,7 @@ export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 command -v plymouth > /dev/null 2>&1 && plymouth --quit
 exec > /dev/console 2>&1
 
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 
 export TERM=linux
 export PS1='initramfs-test:\w\$ '

--- a/test/TEST-02-SYSTEMD/test.sh
+++ b/test/TEST-02-SYSTEMD/test.sh
@@ -6,23 +6,21 @@ test_check() {
     command -v systemctl &> /dev/null
 }
 
-KVERSION="${KVERSION-$(uname -r)}"
-
 # Uncomment this to debug failures
 #DEBUGFAIL="rd.shell=1 rd.break=pre-mount"
 test_run() {
-    dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
     declare -a disk_args=()
     declare -i disk_index=0
     qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
     qemu_add_drive_args disk_index disk_args "$TESTDIR"/root.img root
 
+    test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot root=LABEL=dracut rw loglevel=77 systemd.log_level=debug systemd.log_target=console rd.retry=3 rd.info console=ttyS0,115200n81 selinux=0 init=/sbin/init rd.shell=0 $DEBUGFAIL" \
         -initrd "$TESTDIR"/initramfs.testing || return 1
 
-    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-success "$TESTDIR"/marker.img
+    test_marker_check || return 1
 }
 
 test_setup() {
@@ -50,19 +48,17 @@ test_setup() {
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
     rm -rf -- "$TESTDIR"/overlay
 
-    dd if=/dev/zero of="$TESTDIR"/root.img bs=1MiB count=80
-    dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/root.img root
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/root.img root 80
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=/dev/fakeroot rw rootfstype=ext4 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd "$TESTDIR"/initramfs.makeroot || return 1
-    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/marker.img || return 1
+    test_marker_check dracut-root-block-created || return 1
     rm -- "$TESTDIR"/marker.img
 
     # systemd-analyze.sh calls man indirectly

--- a/test/TEST-02-SYSTEMD/test.sh
+++ b/test/TEST-02-SYSTEMD/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # shellcheck disable=SC2034
-TEST_DESCRIPTION="root filesystem on a ext3 filesystem"
+TEST_DESCRIPTION="root filesystem on a ext4 filesystem"
 
 test_check() {
     command -v systemctl &> /dev/null
@@ -42,8 +42,8 @@ test_setup() {
     # devices, volume groups, encrypted partitions, etc.
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -m "test-makeroot dash rootfs-block kernel-modules qemu" \
-        -d "piix ide-gd_mod ata_piix ext3 sd_mod" \
-        -I "mkfs.ext3" \
+        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
+        -I "mkfs.ext4" \
         -i ./create-root.sh /lib/dracut/hooks/initqueue/01-create-root.sh \
         --nomdadmconf \
         --no-hostonly-cmdline -N \
@@ -60,7 +60,7 @@ test_setup() {
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "root=/dev/fakeroot rw rootfstype=ext3 quiet console=ttyS0,115200n81 selinux=0" \
+        -append "root=/dev/fakeroot rw rootfstype=ext4 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd "$TESTDIR"/initramfs.makeroot || return 1
     grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/marker.img || return 1
     rm -- "$TESTDIR"/marker.img
@@ -70,7 +70,7 @@ test_setup() {
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -a "test systemd" \
         -o "network kernel-network-modules" \
-        -d "piix ide-gd_mod ata_piix ext3 sd_mod" \
+        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         -i ./systemd-analyze.sh /lib/dracut/hooks/pre-pivot/00-systemd-analyze.sh \
         -i "/bin/true" "/usr/bin/man" \
         --no-hostonly-cmdline -N \

--- a/test/TEST-02-SYSTEMD/test.sh
+++ b/test/TEST-02-SYSTEMD/test.sh
@@ -51,7 +51,7 @@ test_setup() {
     declare -a disk_args=()
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root 80
+    qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root 1
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \

--- a/test/TEST-02-SYSTEMD/test.sh
+++ b/test/TEST-02-SYSTEMD/test.sh
@@ -11,8 +11,8 @@ test_check() {
 test_run() {
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/root.img root
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root
 
     test_marker_reset
     "$testdir"/run-qemu \
@@ -50,8 +50,8 @@ test_setup() {
 
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/root.img root 80
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root 80
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
@@ -66,7 +66,7 @@ test_setup() {
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -a "test systemd" \
         -o "network kernel-network-modules" \
-        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
+        -d "piix ide-gd_mod ata_piix ext4" \
         -i ./systemd-analyze.sh /lib/dracut/hooks/pre-pivot/00-systemd-analyze.sh \
         -i "/bin/true" "/usr/bin/man" \
         --no-hostonly-cmdline -N \

--- a/test/TEST-03-USR-MOUNT/create-root.sh
+++ b/test/TEST-03-USR-MOUNT/create-root.sh
@@ -12,22 +12,22 @@ set -e
 
 udevadm settle
 modprobe btrfs || :
-mkfs.btrfs -L dracut /dev/disk/by-id/ata-disk_root
-mkfs.btrfs -L dracutusr /dev/disk/by-id/ata-disk_usr
-btrfs device scan /dev/disk/by-id/ata-disk_root
-btrfs device scan /dev/disk/by-id/ata-disk_usr
+mkfs.btrfs -L dracut /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root
+mkfs.btrfs -L dracutusr /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_usr
+btrfs device scan /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root
+btrfs device scan /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_usr
 mkdir -p /root
-mount -t btrfs /dev/disk/by-id/ata-disk_root /root
+mount -t btrfs /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root /root
 [ -d /root/usr ] || mkdir -p /root/usr
-mount -t btrfs /dev/disk/by-id/ata-disk_usr /root/usr
+mount -t btrfs /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_usr /root/usr
 btrfs subvolume create /root/usr/usr
 umount /root/usr
-mount -t btrfs -o subvol=usr /dev/disk/by-id/ata-disk_usr /root/usr
+mount -t btrfs -o subvol=usr /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_usr /root/usr
 cp -a -t /root /source/*
 mkdir -p /root/run
 btrfs filesystem sync /root/usr
 btrfs filesystem sync /root
 umount /root/usr
 umount /root
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-03-USR-MOUNT/fstab
+++ b/test/TEST-03-USR-MOUNT/fstab
@@ -1,2 +1,2 @@
-/dev/disk/by-id/ata-disk_root	/                       btrfs   defaults         0 0
-/dev/disk/by-id/ata-disk_usr	/usr                    btrfs   subvol=usr,ro    0 0
+/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root	/                       btrfs   defaults         0 0
+/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_usr	/usr                    btrfs   subvol=usr,ro    0 0

--- a/test/TEST-03-USR-MOUNT/test-init.sh
+++ b/test/TEST-03-USR-MOUNT/test-init.sh
@@ -7,7 +7,7 @@ export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 command -v plymouth > /dev/null 2>&1 && plymouth --quit
 exec > /dev/console 2>&1
 
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 
 export TERM=linux
 export PS1='initramfs-test:\w\$ '

--- a/test/TEST-03-USR-MOUNT/test.sh
+++ b/test/TEST-03-USR-MOUNT/test.sh
@@ -70,8 +70,8 @@ test_setup() {
     declare -a disk_args=()
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/root.btrfs root 160
-    qemu_add_drive disk_index disk_args "$TESTDIR"/usr.btrfs usr 160
+    qemu_add_drive disk_index disk_args "$TESTDIR"/root.btrfs root 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/usr.btrfs usr 1
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \

--- a/test/TEST-03-USR-MOUNT/test.sh
+++ b/test/TEST-03-USR-MOUNT/test.sh
@@ -15,9 +15,9 @@ client_run() {
 
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/root.btrfs root
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/usr.btrfs usr
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive disk_index disk_args "$TESTDIR"/root.btrfs root
+    qemu_add_drive disk_index disk_args "$TESTDIR"/usr.btrfs usr
 
     test_marker_reset
     "$testdir"/run-qemu \
@@ -69,9 +69,9 @@ test_setup() {
     # Create the blank file to use as a root filesystem
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/root.btrfs root 160
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/usr.btrfs usr 160
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/root.btrfs root 160
+    qemu_add_drive disk_index disk_args "$TESTDIR"/usr.btrfs usr 160
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
@@ -87,7 +87,7 @@ test_setup() {
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -a "test watchdog" \
         -o "network kernel-network-modules" \
-        -d "piix ide-gd_mod ata_piix btrfs sd_mod i6300esb ib700wdt" \
+        -d "piix ide-gd_mod ata_piix btrfs i6300esb ib700wdt" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1
     rm -rf -- "$TESTDIR"/overlay

--- a/test/TEST-04-FULL-SYSTEMD/create-root.sh
+++ b/test/TEST-04-FULL-SYSTEMD/create-root.sh
@@ -12,22 +12,22 @@ set -e
 
 udevadm settle
 modprobe btrfs || :
-mkfs.btrfs -L dracut /dev/disk/by-id/ata-disk_root
-mkfs.btrfs -L dracutusr /dev/disk/by-id/ata-disk_usr
-btrfs device scan /dev/disk/by-id/ata-disk_root
-btrfs device scan /dev/disk/by-id/ata-disk_usr
+mkfs.btrfs -L dracut /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root
+mkfs.btrfs -L dracutusr /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_usr
+btrfs device scan /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root
+btrfs device scan /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_usr
 mkdir -p /root
-mount -t btrfs /dev/disk/by-id/ata-disk_root /root
+mount -t btrfs /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root /root
 [ -d /root/usr ] || mkdir -p /root/usr
-mount -t btrfs /dev/disk/by-id/ata-disk_usr /root/usr
+mount -t btrfs /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_usr /root/usr
 btrfs subvolume create /root/usr/usr
 umount /root/usr
-mount -t btrfs -o subvol=usr /dev/disk/by-id/ata-disk_usr /root/usr
+mount -t btrfs -o subvol=usr /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_usr /root/usr
 cp -a -t /root /source/*
 mkdir -p /root/run
 btrfs filesystem sync /root/usr
 btrfs filesystem sync /root
 umount /root/usr
 umount /root
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-04-FULL-SYSTEMD/fstab
+++ b/test/TEST-04-FULL-SYSTEMD/fstab
@@ -1,2 +1,2 @@
-/dev/disk/by-id/ata-disk_root	/                       btrfs   defaults         0 0
-/dev/disk/by-id/ata-disk_usr	/usr                    btrfs   subvol=usr,ro    0 0
+/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root	/                       btrfs   defaults         0 0
+/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_usr	/usr                    btrfs   subvol=usr,ro    0 0

--- a/test/TEST-04-FULL-SYSTEMD/test-init.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test-init.sh
@@ -37,5 +37,4 @@ if getargbool 0 rd.shell; then
     setsid $CTTY sh -i
 fi
 echo "Powering down."
-systemctl --no-block poweroff
-exit 0
+poweroff -f

--- a/test/TEST-04-FULL-SYSTEMD/test-init.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test-init.sh
@@ -21,7 +21,7 @@ else
         echo "**************************FAILED**************************"
 
     else
-        echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+        echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
         echo "All OK"
     fi
 fi

--- a/test/TEST-04-FULL-SYSTEMD/test-init.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test-init.sh
@@ -7,7 +7,7 @@ export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 command -v plymouth > /dev/null 2>&1 && plymouth --quit
 exec > /dev/console 2>&1
 
-systemctl --failed --no-legend --no-pager > /failed
+systemctl --failed --no-legend --no-pager > /run/failed
 
 if ! ismounted /usr; then
     echo "**************************FAILED**************************"
@@ -15,9 +15,9 @@ if ! ismounted /usr; then
     cat /proc/mounts
     echo "**************************FAILED**************************"
 else
-    if [ -s /failed ]; then
+    if [ -s /run/failed ]; then
         echo "**************************FAILED**************************"
-        cat /failed
+        cat /run/failed
         echo "**************************FAILED**************************"
 
     else

--- a/test/TEST-04-FULL-SYSTEMD/test-init.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test-init.sh
@@ -15,6 +15,9 @@ if ! ismounted /usr; then
     cat /proc/mounts
     echo "**************************FAILED**************************"
 else
+    # workaround for bsc#1218710
+    sed -i "/systemd-vconsole-setup.service/d" /run/failed
+
     if [ -s /run/failed ]; then
         echo "**************************FAILED**************************"
         cat /run/failed

--- a/test/TEST-04-FULL-SYSTEMD/test.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test.sh
@@ -132,8 +132,8 @@ EOF
     # shellcheck disable=SC2034
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/root.btrfs root 160
-    qemu_add_drive disk_index disk_args "$TESTDIR"/usr.btrfs usr 160
+    qemu_add_drive disk_index disk_args "$TESTDIR"/root.btrfs root 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/usr.btrfs usr 1
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \

--- a/test/TEST-04-FULL-SYSTEMD/test.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test.sh
@@ -20,9 +20,9 @@ client_run() {
 
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/root.btrfs root
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/usr.btrfs usr
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive disk_index disk_args "$TESTDIR"/root.btrfs root
+    qemu_add_drive disk_index disk_args "$TESTDIR"/usr.btrfs usr
 
     test_marker_reset
     "$testdir"/run-qemu \
@@ -131,9 +131,9 @@ EOF
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/root.btrfs root 160
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/usr.btrfs usr 160
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/root.btrfs root 160
+    qemu_add_drive disk_index disk_args "$TESTDIR"/usr.btrfs usr 160
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
@@ -153,7 +153,7 @@ EOF
         -a "test systemd i18n qemu" \
         ${EXTRA_MACHINE:+-I "$EXTRA_MACHINE"} \
         -o "network plymouth lvm mdraid resume crypt caps dm terminfo usrmount kernel-network-modules rngd" \
-        -d "piix ide-gd_mod ata_piix btrfs sd_mod i6300esb ib700wdt" \
+        -d "piix ide-gd_mod ata_piix btrfs i6300esb ib700wdt" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1
 

--- a/test/TEST-04-FULL-SYSTEMD/test.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test.sh
@@ -53,7 +53,7 @@ test_setup() {
     # Create what will eventually be our root filesystem onto an overlay
     "$basedir"/dracut.sh -l --keep --tmpdir "$TESTDIR" \
         -m "test-root systemd" \
-        -I "ldconfig" \
+        -I "ldconfig sed" \
         -i ./test-init.sh /sbin/test-init \
         -i ./fstab /etc/fstab \
         -i "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh" \

--- a/test/TEST-04-FULL-SYSTEMD/test.sh
+++ b/test/TEST-04-FULL-SYSTEMD/test.sh
@@ -52,7 +52,7 @@ test_setup() {
 
     # Create what will eventually be our root filesystem onto an overlay
     "$basedir"/dracut.sh -l --keep --tmpdir "$TESTDIR" \
-        -m "test-root dbus" \
+        -m "test-root systemd" \
         -I "ldconfig" \
         -i ./test-init.sh /sbin/test-init \
         -i ./fstab /etc/fstab \

--- a/test/TEST-10-RAID/create-root.sh
+++ b/test/TEST-10-RAID/create-root.sh
@@ -22,9 +22,9 @@ lvm pvcreate -ff -y /dev/mapper/dracut_crypt_test
 lvm vgcreate dracut /dev/mapper/dracut_crypt_test
 lvm lvcreate -l 100%FREE -n root dracut
 lvm vgchange -ay
-mke2fs -L root /dev/dracut/root
+mkfs.ext4 -L root /dev/dracut/root
 mkdir -p /sysroot
-mount /dev/dracut/root /sysroot
+mount -t ext4 /dev/dracut/root /sysroot
 cp -a -t /sysroot /source/*
 mkdir -p /sysroot/run
 umount /sysroot

--- a/test/TEST-10-RAID/create-root.sh
+++ b/test/TEST-10-RAID/create-root.sh
@@ -10,7 +10,7 @@ rm -f -- /etc/lvm/lvm.conf
 udevadm control --reload
 udevadm settle
 set -ex
-mdadm --create /dev/md0 --run --auto=yes --level=5 --raid-devices=3 /dev/disk/by-id/ata-disk_raid[123]
+mdadm --create /dev/md0 --run --auto=yes --level=5 --raid-devices=3 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_raid[123]
 # wait for the array to finish initailizing, otherwise this sometimes fails
 # randomly.
 mdadm -W /dev/md0 || :
@@ -42,6 +42,6 @@ eval "$(udevadm info --query=property --name=/dev/md0 | while read -r line || [ 
     echo "dracut-root-block-created"
     echo MD_UUID="$MD_UUID"
     echo "ID_FS_UUID=$ID_FS_UUID"
-} | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+} | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 sync
 poweroff -f

--- a/test/TEST-10-RAID/test-init.sh
+++ b/test/TEST-10-RAID/test-init.sh
@@ -7,7 +7,7 @@ export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 command -v plymouth > /dev/null 2>&1 && plymouth --quit
 exec > /dev/console 2>&1
 
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 
 export TERM=linux
 export PS1='initramfs-test:\w\$ '

--- a/test/TEST-10-RAID/test.sh
+++ b/test/TEST-10-RAID/test.sh
@@ -67,7 +67,7 @@ test_setup() {
         export initdir=$TESTDIR/overlay
         # shellcheck disable=SC1090
         . "$basedir"/dracut-init.sh
-        inst_multiple sfdisk mke2fs poweroff cp umount dd sync grep
+        inst_multiple sfdisk mkfs.ext4 poweroff cp umount dd sync grep
         inst_hook initqueue 01 ./create-root.sh
         inst_hook initqueue/finished 01 ./finished-false.sh
     )
@@ -77,7 +77,7 @@ test_setup() {
     # devices, volume groups, encrypted partitions, etc.
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -m "bash crypt lvm mdraid kernel-modules qemu" \
-        -d "piix ide-gd_mod ata_piix ext2 sd_mod" \
+        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         --nomdadmconf \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
@@ -98,7 +98,7 @@ test_setup() {
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "root=/dev/cannotreach rw rootfstype=ext2 console=ttyS0,115200n81 selinux=0" \
+        -append "root=/dev/cannotreach rw rootfstype=ext4 console=ttyS0,115200n81 selinux=0" \
         -initrd "$TESTDIR"/initramfs.makeroot || return 1
     grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/marker.img || return 1
     eval "$(grep -F -a -m 1 ID_FS_UUID "$TESTDIR"/marker.img)"
@@ -121,7 +121,7 @@ test_setup() {
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -o "plymouth network kernel-network-modules" \
         -a "debug" \
-        -d "piix ide-gd_mod ata_piix ext2 sd_mod" \
+        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1
 }

--- a/test/TEST-10-RAID/test.sh
+++ b/test/TEST-10-RAID/test.sh
@@ -2,13 +2,10 @@
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="root filesystem on an encrypted LVM PV on a RAID-5"
 
-KVERSION=${KVERSION-$(uname -r)}
-
 # Uncomment this to debug failures
 #DEBUGFAIL="rd.shell rd.udev.log-priority=debug loglevel=70 systemd.log_target=kmsg"
 #DEBUGFAIL="rd.break rd.shell rd.debug debug"
 test_run() {
-    dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
@@ -17,12 +14,13 @@ test_run() {
     qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-2.img raid2
     qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-3.img raid3
 
+    test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot root=/dev/dracut/root rd.auto rw rd.retry=10 console=ttyS0,115200n81 selinux=0 rd.shell=0 $DEBUGFAIL" \
         -initrd "$TESTDIR"/initramfs.testing || return 1
 
-    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-success "$TESTDIR"/marker.img
+    test_marker_check || return 1
 }
 
 test_setup() {
@@ -84,23 +82,19 @@ test_setup() {
     rm -rf -- "$TESTDIR"/overlay
 
     # Create the blank files to use as a root filesystem
-    dd if=/dev/zero of="$TESTDIR"/raid-1.img bs=1MiB count=40
-    dd if=/dev/zero of="$TESTDIR"/raid-2.img bs=1MiB count=40
-    dd if=/dev/zero of="$TESTDIR"/raid-3.img bs=1MiB count=40
-    dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-1.img raid1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-2.img raid2
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-3.img raid3
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-1.img raid1 40
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-2.img raid2 40
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-3.img raid3 40
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=/dev/cannotreach rw rootfstype=ext4 console=ttyS0,115200n81 selinux=0" \
         -initrd "$TESTDIR"/initramfs.makeroot || return 1
-    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/marker.img || return 1
+    test_marker_check dracut-root-block-created || return 1
     eval "$(grep -F -a -m 1 ID_FS_UUID "$TESTDIR"/marker.img)"
 
     (

--- a/test/TEST-10-RAID/test.sh
+++ b/test/TEST-10-RAID/test.sh
@@ -9,10 +9,10 @@ test_run() {
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-1.img raid1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-2.img raid2
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-3.img raid3
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-1.img raid1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-2.img raid2
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-3.img raid3
 
     test_marker_reset
     "$testdir"/run-qemu \
@@ -85,10 +85,10 @@ test_setup() {
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-1.img raid1 40
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-2.img raid2 40
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-3.img raid3 40
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-1.img raid1 40
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-2.img raid2 40
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-3.img raid3 40
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
@@ -115,7 +115,7 @@ test_setup() {
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -o "plymouth network kernel-network-modules" \
         -a "debug" \
-        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
+        -d "piix ide-gd_mod ata_piix ext4" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1
 }

--- a/test/TEST-10-RAID/test.sh
+++ b/test/TEST-10-RAID/test.sh
@@ -86,9 +86,9 @@ test_setup() {
     # shellcheck disable=SC2034
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-1.img raid1 40
-    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-2.img raid2 40
-    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-3.img raid3 40
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-1.img raid1 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-2.img raid2 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-3.img raid3 1
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \

--- a/test/TEST-11-LVM/create-root.sh
+++ b/test/TEST-11-LVM/create-root.sh
@@ -11,11 +11,11 @@ udevadm control --reload
 udevadm settle
 
 set -ex
-for dev in /dev/disk/by-id/ata-disk_disk[123]; do
+for dev in /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk[123]; do
     lvm pvcreate -ff -y "$dev"
 done
 
-lvm vgcreate dracut /dev/disk/by-id/ata-disk_disk[123]
+lvm vgcreate dracut /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk[123]
 lvm lvcreate -l 100%FREE -n root dracut
 lvm vgchange -ay
 mkfs.ext4 /dev/dracut/root
@@ -24,5 +24,5 @@ mount -t ext4 /dev/dracut/root /sysroot
 cp -a -t /sysroot /source/*
 umount /sysroot
 lvm lvchange -a n /dev/dracut/root
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-11-LVM/create-root.sh
+++ b/test/TEST-11-LVM/create-root.sh
@@ -18,9 +18,9 @@ done
 lvm vgcreate dracut /dev/disk/by-id/ata-disk_disk[123]
 lvm lvcreate -l 100%FREE -n root dracut
 lvm vgchange -ay
-mke2fs /dev/dracut/root
+mkfs.ext4 /dev/dracut/root
 mkdir -p /sysroot
-mount /dev/dracut/root /sysroot
+mount -t ext4 /dev/dracut/root /sysroot
 cp -a -t /sysroot /source/*
 umount /sysroot
 lvm lvchange -a n /dev/dracut/root

--- a/test/TEST-11-LVM/test-init.sh
+++ b/test/TEST-11-LVM/test-init.sh
@@ -7,7 +7,7 @@ export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 command -v plymouth > /dev/null 2>&1 && plymouth --quit
 exec > /dev/console 2>&1
 
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 
 export TERM=linux
 export PS1='initramfs-test:\w\$ '

--- a/test/TEST-11-LVM/test.sh
+++ b/test/TEST-11-LVM/test.sh
@@ -68,7 +68,7 @@ test_setup() {
         export initdir=$TESTDIR/overlay
         # shellcheck disable=SC1090
         . "$basedir"/dracut-init.sh
-        inst_multiple sfdisk mke2fs poweroff cp umount dd sync
+        inst_multiple sfdisk mkfs.ext4 poweroff cp umount dd sync
         inst_hook initqueue 01 ./create-root.sh
         inst_hook initqueue/finished 01 ./finished-false.sh
     )
@@ -78,7 +78,7 @@ test_setup() {
     # devices, volume groups, encrypted partitions, etc.
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -m "bash lvm mdraid kernel-modules qemu" \
-        -d "piix ide-gd_mod ata_piix ext2 sd_mod" \
+        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
     rm -rf -- "$TESTDIR"/overlay
@@ -98,7 +98,7 @@ test_setup() {
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "root=/dev/fakeroot rw rootfstype=ext2 quiet console=ttyS0,115200n81 selinux=0" \
+        -append "root=/dev/fakeroot rw rootfstype=ext4 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd "$TESTDIR"/initramfs.makeroot || return 1
     grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/marker.img || return 1
 
@@ -114,7 +114,7 @@ test_setup() {
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -o "plymouth network kernel-network-modules" \
         -a "debug" \
-        -d "piix ide-gd_mod ata_piix ext2 sd_mod" \
+        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1
 }

--- a/test/TEST-11-LVM/test.sh
+++ b/test/TEST-11-LVM/test.sh
@@ -86,9 +86,9 @@ test_setup() {
     # shellcheck disable=SC2034
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-1.img disk1 40
-    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-2.img disk2 40
-    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-3.img disk3 40
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-1.img disk1 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-2.img disk2 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-3.img disk3 1
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \

--- a/test/TEST-11-LVM/test.sh
+++ b/test/TEST-11-LVM/test.sh
@@ -10,10 +10,10 @@ test_run() {
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-1.img disk1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-2.img disk2
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-3.img disk3
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-1.img disk1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-2.img disk2
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-3.img disk3
 
     test_marker_reset
     "$testdir"/run-qemu \
@@ -85,10 +85,10 @@ test_setup() {
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-1.img disk1 40
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-2.img disk2 40
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-3.img disk3 40
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-1.img disk1 40
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-2.img disk2 40
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-3.img disk3 40
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
@@ -108,7 +108,7 @@ test_setup() {
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -o "plymouth network kernel-network-modules" \
         -a "debug" \
-        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
+        -d "piix ide-gd_mod ata_piix ext4" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1
 }

--- a/test/TEST-12-RAID-DEG/create-root.sh
+++ b/test/TEST-12-RAID-DEG/create-root.sh
@@ -22,9 +22,9 @@ lvm pvcreate -ff -y /dev/mapper/dracut_crypt_test
 lvm vgcreate dracut /dev/mapper/dracut_crypt_test
 lvm lvcreate -l 100%FREE -n root dracut
 lvm vgchange -ay
-mke2fs -L root /dev/dracut/root
+mkfs.ext4 -L root /dev/dracut/root
 mkdir -p /sysroot
-mount /dev/dracut/root /sysroot
+mount -t ext4 /dev/dracut/root /sysroot
 cp -a -t /sysroot /source/*
 mkdir -p /sysroot/run
 umount /sysroot

--- a/test/TEST-12-RAID-DEG/create-root.sh
+++ b/test/TEST-12-RAID-DEG/create-root.sh
@@ -10,7 +10,7 @@ rm -f -- /etc/lvm/lvm.conf
 udevadm control --reload
 udevadm settle
 set -ex
-mdadm --create /dev/md0 --run --auto=yes --level=5 --raid-devices=3 /dev/disk/by-id/ata-disk_raid[123]
+mdadm --create /dev/md0 --run --auto=yes --level=5 --raid-devices=3 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_raid[123]
 # wait for the array to finish initailizing, otherwise this sometimes fails
 # randomly.
 mdadm -W /dev/md0 || :
@@ -42,6 +42,6 @@ eval "$(udevadm info --query=property --name=/dev/md0 | while read -r line || [ 
     echo "dracut-root-block-created"
     echo MD_UUID="$MD_UUID"
     echo "ID_FS_UUID=$ID_FS_UUID"
-} | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+} | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 sync
 poweroff -f

--- a/test/TEST-12-RAID-DEG/test-init.sh
+++ b/test/TEST-12-RAID-DEG/test-init.sh
@@ -7,7 +7,7 @@ export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 command -v plymouth > /dev/null 2>&1 && plymouth --quit
 exec > /dev/console 2>&1
 
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 
 export TERM=linux
 export PS1='initramfs-test:\w\$ '

--- a/test/TEST-12-RAID-DEG/test.sh
+++ b/test/TEST-12-RAID-DEG/test.sh
@@ -98,7 +98,7 @@ test_setup() {
         export initdir=$TESTDIR/overlay
         # shellcheck disable=SC1090
         . "$basedir"/dracut-init.sh
-        inst_multiple sfdisk mke2fs poweroff cp umount dd grep sync
+        inst_multiple sfdisk mkfs.ext4 poweroff cp umount dd grep sync
         inst_hook initqueue 01 ./create-root.sh
         inst_hook initqueue/finished 01 ./finished-false.sh
     )
@@ -108,7 +108,7 @@ test_setup() {
     # devices, volume groups, encrypted partitions, etc.
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -m "bash crypt lvm mdraid kernel-modules qemu" \
-        -d "piix ide-gd_mod ata_piix ext2 sd_mod" \
+        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
     rm -rf -- "$TESTDIR"/overlay
@@ -128,7 +128,7 @@ test_setup() {
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "root=/dev/fakeroot rw rootfstype=ext2 quiet console=ttyS0,115200n81 selinux=0" \
+        -append "root=/dev/fakeroot rw rootfstype=ext4 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd "$TESTDIR"/initramfs.makeroot || return 1
 
     grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/marker.img || return 1
@@ -157,7 +157,7 @@ test_setup() {
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -o "plymouth network kernel-network-modules" \
         -a "debug" \
-        -d "piix ide-gd_mod ata_piix ext2 sd_mod" \
+        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1
 }

--- a/test/TEST-12-RAID-DEG/test.sh
+++ b/test/TEST-12-RAID-DEG/test.sh
@@ -13,11 +13,11 @@ client_run() {
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
     # degrade the RAID
-    # qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-1.img raid1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-2.img raid2
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-3.img raid3
+    # qemu_add_drive disk_index disk_args "$TESTDIR"/raid-1.img raid1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-2.img raid2
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-3.img raid3
 
     test_marker_reset
     "$testdir"/run-qemu \
@@ -115,10 +115,10 @@ test_setup() {
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-1.img raid1 40
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-2.img raid2 40
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-3.img raid3 40
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-1.img raid1 40
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-2.img raid2 40
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-3.img raid3 40
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
@@ -151,7 +151,7 @@ test_setup() {
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -o "plymouth network kernel-network-modules" \
         -a "debug" \
-        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
+        -d "piix ide-gd_mod ata_piix ext4" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1
 }

--- a/test/TEST-12-RAID-DEG/test.sh
+++ b/test/TEST-12-RAID-DEG/test.sh
@@ -116,9 +116,9 @@ test_setup() {
     # shellcheck disable=SC2034
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-1.img raid1 40
-    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-2.img raid2 40
-    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-3.img raid3 40
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-1.img raid1 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-2.img raid2 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-3.img raid3 1
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \

--- a/test/TEST-13-ENC-RAID-LVM/create-root.sh
+++ b/test/TEST-13-ENC-RAID-LVM/create-root.sh
@@ -28,9 +28,9 @@ lvm vgcreate dracut /dev/md0
 
 lvm lvcreate -l 100%FREE -n root dracut
 lvm vgchange -ay
-mke2fs /dev/dracut/root
+mkfs.ext4 /dev/dracut/root
 mkdir -p /sysroot
-mount /dev/dracut/root /sysroot
+mount -t ext4 /dev/dracut/root /sysroot
 cp -a -t /sysroot /source/*
 umount /sysroot
 lvm lvchange -a n /dev/dracut/root

--- a/test/TEST-13-ENC-RAID-LVM/create-root.sh
+++ b/test/TEST-13-ENC-RAID-LVM/create-root.sh
@@ -13,12 +13,12 @@ udevadm settle
 
 set -ex
 printf test > keyfile
-cryptsetup -q luksFormat /dev/disk/by-id/ata-disk_disk1 /keyfile
-cryptsetup -q luksFormat /dev/disk/by-id/ata-disk_disk2 /keyfile
-cryptsetup -q luksFormat /dev/disk/by-id/ata-disk_disk3 /keyfile
-cryptsetup luksOpen /dev/disk/by-id/ata-disk_disk1 dracut_disk1 < /keyfile
-cryptsetup luksOpen /dev/disk/by-id/ata-disk_disk2 dracut_disk2 < /keyfile
-cryptsetup luksOpen /dev/disk/by-id/ata-disk_disk3 dracut_disk3 < /keyfile
+cryptsetup -q luksFormat /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk1 /keyfile
+cryptsetup -q luksFormat /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk2 /keyfile
+cryptsetup -q luksFormat /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk3 /keyfile
+cryptsetup luksOpen /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk1 dracut_disk1 < /keyfile
+cryptsetup luksOpen /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk2 dracut_disk2 < /keyfile
+cryptsetup luksOpen /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk3 dracut_disk3 < /keyfile
 mdadm --create /dev/md0 --run --auto=yes --level=5 --raid-devices=3 /dev/mapper/dracut_disk1 /dev/mapper/dracut_disk2 /dev/mapper/dracut_disk3
 # wait for the array to finish initailizing, otherwise this sometimes fails
 # randomly.
@@ -42,9 +42,9 @@ cryptsetup luksClose /dev/mapper/dracut_disk3
 
 {
     echo "dracut-root-block-created"
-    for i in /dev/disk/by-id/ata-disk_disk[123]; do
+    for i in /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk[123]; do
         udevadm info --query=property --name="$i" | grep -F 'ID_FS_UUID='
     done
-} | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+} | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 sync
 poweroff -f

--- a/test/TEST-13-ENC-RAID-LVM/test-init.sh
+++ b/test/TEST-13-ENC-RAID-LVM/test-init.sh
@@ -7,7 +7,7 @@ export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 command -v plymouth > /dev/null 2>&1 && plymouth --quit
 exec > /dev/console 2>&1
 
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 
 export TERM=linux
 export PS1='initramfs-test:\w\$ '

--- a/test/TEST-13-ENC-RAID-LVM/test.sh
+++ b/test/TEST-13-ENC-RAID-LVM/test.sh
@@ -95,7 +95,7 @@ test_setup() {
         export initdir=$TESTDIR/overlay
         # shellcheck disable=SC1090
         . "$basedir"/dracut-init.sh
-        inst_multiple sfdisk mke2fs poweroff cp umount grep dd sync
+        inst_multiple sfdisk mkfs.ext4 poweroff cp umount grep dd sync
         inst_hook initqueue 01 ./create-root.sh
         inst_hook initqueue/finished 01 ./finished-false.sh
     )
@@ -105,7 +105,7 @@ test_setup() {
     # devices, volume groups, encrypted partitions, etc.
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -m "bash crypt lvm mdraid kernel-modules qemu" \
-        -d "piix ide-gd_mod ata_piix ext2 sd_mod" \
+        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
     rm -rf -- "$TESTDIR"/overlay
@@ -125,7 +125,7 @@ test_setup() {
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "root=/dev/fakeroot rw rootfstype=ext2 quiet console=ttyS0,115200n81 selinux=0" \
+        -append "root=/dev/fakeroot rw rootfstype=ext4 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd "$TESTDIR"/initramfs.makeroot || return 1
     grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/marker.img || return 1
     cryptoUUIDS=$(grep -F --binary-files=text -m 3 ID_FS_UUID "$TESTDIR"/marker.img)
@@ -156,7 +156,7 @@ test_setup() {
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -o "plymouth network kernel-network-modules" \
         -a "debug" \
-        -d "piix ide-gd_mod ata_piix ext2 sd_mod" \
+        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1
 }

--- a/test/TEST-13-ENC-RAID-LVM/test.sh
+++ b/test/TEST-13-ENC-RAID-LVM/test.sh
@@ -15,10 +15,10 @@ test_run() {
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-1.img disk1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-2.img disk2
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-3.img disk3
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-1.img disk1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-2.img disk2
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-3.img disk3
 
     test_marker_reset
     "$testdir"/run-qemu \
@@ -111,10 +111,10 @@ test_setup() {
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-1.img disk1 40
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-2.img disk2 40
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-3.img disk3 40
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-1.img disk1 80
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-2.img disk2 80
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-3.img disk3 80
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
@@ -140,7 +140,7 @@ test_setup() {
         i=1
         for uuid in $cryptoUUIDS; do
             eval "$uuid"
-            printf 'luks-%s /dev/disk/by-id/ata-disk_disk%s /etc/key timeout=0\n' "$ID_FS_UUID" $i
+            printf 'luks-%s /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk%s /etc/key timeout=0\n' "$ID_FS_UUID" $i
             ((i += 1))
         done > "$initdir"/etc/crypttab
         echo -n test > "$initdir"/etc/key

--- a/test/TEST-13-ENC-RAID-LVM/test.sh
+++ b/test/TEST-13-ENC-RAID-LVM/test.sh
@@ -112,9 +112,9 @@ test_setup() {
     # shellcheck disable=SC2034
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-1.img disk1 80
-    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-2.img disk2 80
-    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-3.img disk3 80
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-1.img disk1 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-2.img disk2 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-3.img disk3 1
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \

--- a/test/TEST-14-IMSM/create-root.sh
+++ b/test/TEST-14-IMSM/create-root.sh
@@ -12,7 +12,7 @@ udevadm control --reload
 udevadm settle
 
 # dmraid does not want symlinks in --disk "..."
-echo y | dmraid -f isw -C Test0 --type 1 --disk "$(realpath /dev/disk/by-id/ata-disk_disk1) $(realpath /dev/disk/by-id/ata-disk_disk2)"
+echo y | dmraid -f isw -C Test0 --type 1 --disk "$(realpath /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk1) $(realpath /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk2)"
 udevadm settle
 
 SETS=$(dmraid -c -s)
@@ -72,7 +72,7 @@ echo "MD_UUID=$MD_UUID"
 {
     echo "dracut-root-block-created"
     echo MD_UUID="$MD_UUID"
-} | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+} | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 mdadm --wait-clean /dev/md0
 sync
 poweroff -f

--- a/test/TEST-14-IMSM/create-root.sh
+++ b/test/TEST-14-IMSM/create-root.sh
@@ -59,9 +59,9 @@ lvm pvcreate -ff -y /dev/md0
 lvm vgcreate dracut /dev/md0
 lvm lvcreate -l 100%FREE -n root dracut
 lvm vgchange -ay
-mke2fs -L root /dev/dracut/root
+mkfs.ext4 -L root /dev/dracut/root
 mkdir -p /sysroot
-mount /dev/dracut/root /sysroot
+mount -t ext4 /dev/dracut/root /sysroot
 cp -a -t /sysroot /source/*
 umount /sysroot
 lvm lvchange -a n /dev/dracut/root

--- a/test/TEST-14-IMSM/test-init.sh
+++ b/test/TEST-14-IMSM/test-init.sh
@@ -7,7 +7,7 @@ export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 command -v plymouth > /dev/null 2>&1 && plymouth --quit
 exec > /dev/console 2>&1
 
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 
 export TERM=linux
 export PS1='initramfs-test:\w\$ '

--- a/test/TEST-14-IMSM/test.sh
+++ b/test/TEST-14-IMSM/test.sh
@@ -93,7 +93,7 @@ test_setup() {
         export initdir=$TESTDIR/overlay
         # shellcheck disable=SC1090
         . "$basedir"/dracut-init.sh
-        inst_multiple sfdisk mke2fs poweroff cp umount grep dd sync realpath
+        inst_multiple sfdisk mkfs.ext4 poweroff cp umount grep dd sync realpath
         inst_hook initqueue 01 ./create-root.sh
     )
 
@@ -102,7 +102,7 @@ test_setup() {
     # devices, volume groups, encrypted partitions, etc.
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -m "bash lvm mdraid dmraid kernel-modules qemu" \
-        -d "piix ide-gd_mod ata_piix ext2 sd_mod dm-multipath dm-crypt dm-round-robin faulty linear multipath raid0 raid10 raid1 raid456" \
+        -d "piix ide-gd_mod ata_piix ext4 sd_mod dm-multipath dm-crypt dm-round-robin faulty linear multipath raid0 raid10 raid1 raid456" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
     rm -rf -- "$TESTDIR"/overlay
@@ -121,7 +121,7 @@ test_setup() {
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "root=/dev/dracut/root rw rootfstype=ext2 quiet console=ttyS0,115200n81 selinux=0" \
+        -append "root=/dev/dracut/root rw rootfstype=ext4 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd "$TESTDIR"/initramfs.makeroot || return 1
     grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/marker.img || return 1
     eval "$(grep -F --binary-files=text -m 1 MD_UUID "$TESTDIR"/marker.img)"
@@ -144,7 +144,7 @@ test_setup() {
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -o "plymouth network kernel-network-modules" \
         -a "debug" \
-        -d "piix ide-gd_mod ata_piix ext2 sd_mod" \
+        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1
 }

--- a/test/TEST-14-IMSM/test.sh
+++ b/test/TEST-14-IMSM/test.sh
@@ -110,8 +110,8 @@ test_setup() {
     # shellcheck disable=SC2034
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-1.img disk1 200
-    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-2.img disk2 200
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-1.img disk1 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-2.img disk2 1
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \

--- a/test/TEST-14-IMSM/test.sh
+++ b/test/TEST-14-IMSM/test.sh
@@ -12,9 +12,9 @@ client_run() {
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-1.img disk1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-2.img disk2
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-1.img disk1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-2.img disk2
 
     test_marker_reset
     "$testdir"/run-qemu \
@@ -109,9 +109,9 @@ test_setup() {
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-1.img disk1 100
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-2.img disk2 100
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-1.img disk1 200
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-2.img disk2 200
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
@@ -139,7 +139,7 @@ test_setup() {
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -o "plymouth network kernel-network-modules" \
         -a "debug" \
-        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
+        -d "piix ide-gd_mod ata_piix ext4" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1
 }

--- a/test/TEST-15-BTRFSRAID/create-root.sh
+++ b/test/TEST-15-BTRFSRAID/create-root.sh
@@ -12,17 +12,17 @@ udevadm settle
 
 set -e
 
-mkfs.btrfs -draid10 -mraid10 -L root /dev/disk/by-id/ata-disk_raid[1234]
+mkfs.btrfs -draid10 -mraid10 -L root /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_raid[1234]
 udevadm settle
 
 btrfs device scan
 udevadm settle
 
 mkdir -p /sysroot
-mount -t btrfs /dev/disk/by-id/ata-disk_raid4 /sysroot
+mount -t btrfs /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_raid4 /sysroot
 cp -a -t /sysroot /source/*
 umount /sysroot
 
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 sync
 poweroff -f

--- a/test/TEST-15-BTRFSRAID/test-init.sh
+++ b/test/TEST-15-BTRFSRAID/test-init.sh
@@ -7,7 +7,7 @@ export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 command -v plymouth > /dev/null 2>&1 && plymouth --quit
 exec > /dev/console 2>&1
 
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 
 export TERM=linux
 export PS1='initramfs-test:\w\$ '

--- a/test/TEST-15-BTRFSRAID/test.sh
+++ b/test/TEST-15-BTRFSRAID/test.sh
@@ -8,11 +8,11 @@ test_run() {
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-1.img raid1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-2.img raid2
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-3.img raid3
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-4.img raid4
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-1.img raid1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-2.img raid2
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-3.img raid3
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-4.img raid4
 
     test_marker_reset
     "$testdir"/run-qemu \
@@ -89,11 +89,11 @@ test_setup() {
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-1.img raid1 150
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-2.img raid2 150
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-3.img raid3 150
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid-4.img raid4 150
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-1.img raid1 150
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-2.img raid2 150
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-3.img raid3 150
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-4.img raid4 150
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
@@ -114,7 +114,7 @@ test_setup() {
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -o "plymouth network kernel-network-modules" \
         -a "debug" \
-        -d "piix ide-gd_mod ata_piix btrfs sd_mod" \
+        -d "piix ide-gd_mod ata_piix btrfs" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1
 }

--- a/test/TEST-15-BTRFSRAID/test.sh
+++ b/test/TEST-15-BTRFSRAID/test.sh
@@ -90,10 +90,10 @@ test_setup() {
     # shellcheck disable=SC2034
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-1.img raid1 150
-    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-2.img raid2 150
-    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-3.img raid3 150
-    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-4.img raid4 150
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-1.img raid1 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-2.img raid2 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-3.img raid3 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid-4.img raid4 1
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \

--- a/test/TEST-16-DMSQUASH/create-root.sh
+++ b/test/TEST-16-DMSQUASH/create-root.sh
@@ -21,7 +21,7 @@ udevadm settle
 
 mkfs.ext4 -q -L dracut /dev/disk/by-id/ata-disk_root-part1
 mkdir -p /root
-mount /dev/disk/by-id/ata-disk_root-part1 /root
+mount -t ext4 /dev/disk/by-id/ata-disk_root-part1 /root
 mkdir -p /root/run /root/testdir
 cp -a -t /root /source/*
 echo "Creating squashfs"

--- a/test/TEST-16-DMSQUASH/create-root.sh
+++ b/test/TEST-16-DMSQUASH/create-root.sh
@@ -13,19 +13,19 @@ set -e
 udevadm settle
 
 # create a single partition using 50% of the capacity of the image file created by test_setup() in test.sh
-sfdisk /dev/disk/by-id/ata-disk_root << EOF
+sfdisk /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root << EOF
 2048,161792
 EOF
 
 udevadm settle
 
-mkfs.ext4 -q -L dracut /dev/disk/by-id/ata-disk_root-part1
+mkfs.ext4 -q -L dracut /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root-part1
 mkdir -p /root
-mount -t ext4 /dev/disk/by-id/ata-disk_root-part1 /root
+mount -t ext4 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root-part1 /root
 mkdir -p /root/run /root/testdir
 cp -a -t /root /source/*
 echo "Creating squashfs"
 mksquashfs /source /root/testdir/rootfs.img -quiet
 umount /root
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-16-DMSQUASH/test-init.sh
+++ b/test/TEST-16-DMSQUASH/test-init.sh
@@ -7,7 +7,7 @@ export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 command -v plymouth > /dev/null 2>&1 && plymouth --quit
 exec > /dev/console 2>&1
 
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 
 if grep -qF ' rd.live.overlay=LABEL=persist ' /proc/cmdline; then
     # Writing to a file in the root filesystem lets test_run() verify that the autooverlay module successfully created

--- a/test/TEST-16-DMSQUASH/test.sh
+++ b/test/TEST-16-DMSQUASH/test.sh
@@ -83,7 +83,7 @@ test_setup() {
     declare -a disk_args=()
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root 160
+    qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root 1
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \

--- a/test/TEST-16-DMSQUASH/test.sh
+++ b/test/TEST-16-DMSQUASH/test.sh
@@ -9,8 +9,8 @@ TEST_DESCRIPTION="live root on a squash filesystem"
 test_run() {
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/root.img root
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root
 
     test_marker_reset
     "$testdir"/run-qemu \
@@ -82,8 +82,8 @@ test_setup() {
     # Create the blank file to use as a root filesystem
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/root.img root 160
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/root.img root 160
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
@@ -107,7 +107,7 @@ test_setup() {
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         --modules "test dmsquash-live-autooverlay qemu" \
         --omit "rngd" \
-        --drivers "ext4 sd_mod" \
+        --drivers "ext4" \
         --install "mkfs.ext4" \
         --no-hostonly --no-hostonly-cmdline \
         --force "$TESTDIR"/initramfs.testing-autooverlay "$KVERSION" || return 1

--- a/test/TEST-17-LVM-THIN/create-root.sh
+++ b/test/TEST-17-LVM-THIN/create-root.sh
@@ -19,9 +19,9 @@ lvm vgcreate dracut /dev/disk/by-id/ata-disk_disk[123]
 lvm lvcreate --ignoremonitoring -l 17 -T dracut/mythinpool
 lvm lvcreate --ignoremonitoring -V1G -T dracut/mythinpool -n root
 lvm vgchange --ignoremonitoring -ay
-mke2fs /dev/dracut/root
+mkfs.ext4 /dev/dracut/root
 mkdir -p /sysroot
-mount /dev/dracut/root /sysroot
+mount -t ext4 /dev/dracut/root /sysroot
 cp -a -t /sysroot /source/*
 umount /sysroot
 lvm lvchange -a n /dev/dracut/root

--- a/test/TEST-17-LVM-THIN/create-root.sh
+++ b/test/TEST-17-LVM-THIN/create-root.sh
@@ -11,11 +11,11 @@ udevadm control --reload
 udevadm settle
 
 set -ex
-for dev in /dev/disk/by-id/ata-disk_disk[123]; do
+for dev in /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk[123]; do
     lvm pvcreate -ff -y "$dev"
 done
 
-lvm vgcreate dracut /dev/disk/by-id/ata-disk_disk[123]
+lvm vgcreate dracut /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk[123]
 lvm lvcreate --ignoremonitoring -l 17 -T dracut/mythinpool
 lvm lvcreate --ignoremonitoring -V1G -T dracut/mythinpool -n root
 lvm vgchange --ignoremonitoring -ay
@@ -27,7 +27,7 @@ umount /sysroot
 lvm lvchange -a n /dev/dracut/root
 
 if ! dmsetup status | grep -q out_of_data_space; then
-    echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+    echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 fi
 
 sync

--- a/test/TEST-17-LVM-THIN/test-init.sh
+++ b/test/TEST-17-LVM-THIN/test-init.sh
@@ -7,7 +7,7 @@ export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 command -v plymouth > /dev/null 2>&1 && plymouth --quit
 exec > /dev/console 2>&1
 
-echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-success" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 
 export TERM=linux
 export PS1='initramfs-test:\w\$ '

--- a/test/TEST-17-LVM-THIN/test.sh
+++ b/test/TEST-17-LVM-THIN/test.sh
@@ -2,13 +2,10 @@
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="root filesystem on LVM PV with thin pool"
 
-KVERSION=${KVERSION-$(uname -r)}
-
 # Uncomment this to debug failures
 #DEBUGFAIL="rd.break rd.shell"
 
 test_run() {
-    dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
@@ -17,11 +14,12 @@ test_run() {
     qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-2.img disk2
     qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-3.img disk3
 
+    test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot root=/dev/dracut/root rw rd.auto=1 quiet rd.retry=3 rd.info console=ttyS0,115200n81 selinux=0 rd.debug rd.shell=0 $DEBUGFAIL" \
         -initrd "$TESTDIR"/initramfs.testing || return 1
-    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-success "$TESTDIR"/marker.img || return 1
+    test_marker_check || return 1
 }
 
 test_setup() {
@@ -82,23 +80,19 @@ test_setup() {
     rm -rf -- "$TESTDIR"/overlay
 
     # Create the blank files to use as a root filesystem
-    dd if=/dev/zero of="$TESTDIR"/disk-1.img bs=1MiB count=40
-    dd if=/dev/zero of="$TESTDIR"/disk-2.img bs=1MiB count=40
-    dd if=/dev/zero of="$TESTDIR"/disk-3.img bs=1MiB count=40
-    dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-1.img disk1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-2.img disk2
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-3.img disk3
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-1.img disk1 40
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-2.img disk2 40
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-3.img disk3 40
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=/dev/fakeroot rw rootfstype=ext4 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd "$TESTDIR"/initramfs.makeroot || return 1
-    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/marker.img || return 1
+    test_marker_check dracut-root-block-created || return 1
 
     (
         # shellcheck disable=SC2031

--- a/test/TEST-17-LVM-THIN/test.sh
+++ b/test/TEST-17-LVM-THIN/test.sh
@@ -66,7 +66,7 @@ test_setup() {
         export initdir=$TESTDIR/overlay
         # shellcheck disable=SC1090
         . "$basedir"/dracut-init.sh
-        inst_multiple sfdisk mke2fs poweroff cp umount grep dmsetup dd sync
+        inst_multiple sfdisk mkfs.ext4 poweroff cp umount grep dmsetup dd sync
         inst_hook initqueue 01 ./create-root.sh
         inst_hook initqueue/finished 01 ./finished-false.sh
     )
@@ -76,7 +76,7 @@ test_setup() {
     # devices, volume groups, encrypted partitions, etc.
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -m "bash lvm mdraid kernel-modules qemu" \
-        -d "piix ide-gd_mod ata_piix ext2 sd_mod" \
+        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
     rm -rf -- "$TESTDIR"/overlay
@@ -96,7 +96,7 @@ test_setup() {
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "root=/dev/fakeroot rw rootfstype=ext2 quiet console=ttyS0,115200n81 selinux=0" \
+        -append "root=/dev/fakeroot rw rootfstype=ext4 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd "$TESTDIR"/initramfs.makeroot || return 1
     grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/marker.img || return 1
 
@@ -112,7 +112,7 @@ test_setup() {
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -o "plymouth network kernel-network-modules" \
         -a "debug" -I lvs \
-        -d "piix ide-gd_mod ata_piix ext2 sd_mod" \
+        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.testing "$KVERSION" || return 1
 }

--- a/test/TEST-17-LVM-THIN/test.sh
+++ b/test/TEST-17-LVM-THIN/test.sh
@@ -84,9 +84,9 @@ test_setup() {
     # shellcheck disable=SC2034
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-1.img disk1 40
-    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-2.img disk2 40
-    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-3.img disk3 40
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-1.img disk1 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-2.img disk2 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-3.img disk3 1
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \

--- a/test/TEST-17-LVM-THIN/test.sh
+++ b/test/TEST-17-LVM-THIN/test.sh
@@ -9,10 +9,10 @@ test_run() {
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-1.img disk1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-2.img disk2
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-3.img disk3
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-1.img disk1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-2.img disk2
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-3.img disk3
 
     test_marker_reset
     "$testdir"/run-qemu \
@@ -83,10 +83,10 @@ test_setup() {
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-1.img disk1 40
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-2.img disk2 40
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/disk-3.img disk3 40
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-1.img disk1 40
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-2.img disk2 40
+    qemu_add_drive disk_index disk_args "$TESTDIR"/disk-3.img disk3 40
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \

--- a/test/TEST-20-NFS/client-init.sh
+++ b/test/TEST-20-NFS/client-init.sh
@@ -19,7 +19,7 @@ echo "made it to the rootfs! Powering down."
 
 while read -r dev _ fstype opts rest || [ -n "$dev" ]; do
     [ "$fstype" != "nfs" -a "$fstype" != "nfs4" ] && continue
-    echo "nfs-OK $dev $fstype $opts" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+    echo "nfs-OK $dev $fstype $opts" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
     break
 done < /proc/mounts
 

--- a/test/TEST-20-NFS/create-root.sh
+++ b/test/TEST-20-NFS/create-root.sh
@@ -12,12 +12,12 @@ udevadm settle
 
 set -ex
 
-mkfs.ext4 -L dracut /dev/disk/by-id/ata-disk_root
+mkfs.ext4 -L dracut /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root
 mkdir -p /root
-mount -t ext4 /dev/disk/by-id/ata-disk_root /root
+mount -t ext4 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root /root
 cp -a -t /root /source/*
 mkdir -p /root/run
 umount /root
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 sync
 poweroff -f

--- a/test/TEST-20-NFS/create-root.sh
+++ b/test/TEST-20-NFS/create-root.sh
@@ -12,9 +12,9 @@ udevadm settle
 
 set -ex
 
-mkfs.ext3 -L dracut /dev/disk/by-id/ata-disk_root
+mkfs.ext4 -L dracut /dev/disk/by-id/ata-disk_root
 mkdir -p /root
-mount /dev/disk/by-id/ata-disk_root /root
+mount -t ext4 /dev/disk/by-id/ata-disk_root /root
 cp -a -t /root /source/*
 mkdir -p /root/run
 umount /root

--- a/test/TEST-20-NFS/test.sh
+++ b/test/TEST-20-NFS/test.sh
@@ -26,7 +26,7 @@ run_server() {
         -net nic,macaddr=52:54:00:12:34:56,model=e1000 \
         -serial "${SERIAL:-"file:$TESTDIR/server.log"}" \
         -device i6300esb -watchdog-action poweroff \
-        -append "panic=1 oops=panic softlockup_panic=1 root=LABEL=dracut rootfstype=ext3 rw console=ttyS0,115200n81 selinux=0 $SERVER_DEBUG" \
+        -append "panic=1 oops=panic softlockup_panic=1 root=LABEL=dracut rootfstype=ext4 rw console=ttyS0,115200n81 selinux=0 $SERVER_DEBUG" \
         -initrd "$TESTDIR"/initramfs.server \
         -pidfile "$TESTDIR"/server.pid -daemonize || return 1
     chmod 644 "$TESTDIR"/server.pid || return 1
@@ -352,7 +352,7 @@ test_setup() {
         export initdir=$TESTDIR/server/overlay
         # shellcheck disable=SC1090
         . "$basedir"/dracut-init.sh
-        inst_multiple sfdisk mkfs.ext3 poweroff cp umount sync dd
+        inst_multiple sfdisk mkfs.ext4 poweroff cp umount sync dd
         inst_hook initqueue 01 ./create-root.sh
         inst_hook initqueue/finished 01 ./finished-false.sh
     )
@@ -362,7 +362,7 @@ test_setup() {
     # devices, volume groups, encrypted partitions, etc.
     "$basedir"/dracut.sh -l -i "$TESTDIR"/server/overlay / \
         -m "bash rootfs-block kernel-modules qemu" \
-        -d "piix ide-gd_mod ata_piix ext3 sd_mod" \
+        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         --nomdadmconf \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
@@ -379,7 +379,7 @@ test_setup() {
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "root=/dev/dracut/root rw rootfstype=ext3 quiet console=ttyS0,115200n81 selinux=0" \
+        -append "root=/dev/dracut/root rw rootfstype=ext4 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd "$TESTDIR"/initramfs.makeroot || return 1
     grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/marker.img || return 1
 
@@ -416,7 +416,7 @@ test_setup() {
     # Make server's dracut image
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -m "dash rootfs-block debug kernel-modules watchdog qemu network network-legacy" \
-        -d "af_packet piix ide-gd_mod ata_piix ext3 sd_mod e1000 i6300esb" \
+        -d "af_packet piix ide-gd_mod ata_piix ext4 sd_mod e1000 i6300esb" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.server "$KVERSION" || return 1
 

--- a/test/TEST-20-NFS/test.sh
+++ b/test/TEST-20-NFS/test.sh
@@ -1,11 +1,7 @@
 #!/bin/bash
 
-[ -z "$USE_NETWORK" ] && USE_NETWORK="network-legacy"
-
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="root filesystem on NFS with $USE_NETWORK"
-
-KVERSION=${KVERSION-$(uname -r)}
 
 # Uncomment this to debug failures
 #DEBUGFAIL="rd.debug loglevel=7 rd.break=initqueue rd.shell"
@@ -18,7 +14,7 @@ run_server() {
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/server.img root 1
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/server.img root 0 1
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
@@ -56,12 +52,11 @@ client_test() {
     echo "CLIENT TEST START: $test_name"
 
     # Need this so kvm-qemu will boot (needs non-/dev/zero local disk)
-    dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
-
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker2.img marker2 1
     if dhclient --help 2>&1 | grep -q -F -- '--timeout' 2> /dev/null; then
         cmdline="$cmdline rd.net.timeout.dhcp=3"
     fi
@@ -75,7 +70,7 @@ client_test() {
         -initrd "$TESTDIR"/initramfs.testing
 
     # shellcheck disable=SC2181
-    if [[ $? -ne 0 ]] || ! grep -U --binary-files=binary -F -m 1 -q nfs-OK "$TESTDIR"/marker.img; then
+    if [[ $? -ne 0 ]] || ! test_marker_check nfs-OK; then
         echo "CLIENT TEST END: $test_name [FAILED - BAD EXIT]"
         return 1
     fi
@@ -115,6 +110,11 @@ client_test() {
             echo "CLIENT TEST INFO: missing: $check_opt"
             echo "CLIENT TEST END: $test_name [FAILED - MISSING OPTION]"
         fi
+        return 1
+    fi
+
+    if ! test_marker_check nfsfetch-OK marker2.img; then
+        echo "CLIENT TEST END: $test_name [FAILED - NFS FETCH FAILED]"
         return 1
     fi
 
@@ -260,6 +260,7 @@ test_setup() {
         done
         type -P portmap > /dev/null && inst_multiple portmap
         type -P rpcbind > /dev/null && inst_multiple rpcbind
+
         [ -f /etc/netconfig ] && inst_multiple /etc/netconfig
         type -P dhcpd > /dev/null && inst_multiple dhcpd
         [ -x /usr/sbin/dhcpd3 ] && inst /usr/sbin/dhcpd3 /usr/sbin/dhcpd
@@ -305,6 +306,7 @@ test_setup() {
         (
             cd "$initdir" || exit
             mkdir -p dev sys proc etc run root usr var/lib/nfs/rpc_pipefs
+            echo "TEST FETCH FILE" > root/fetchfile
         )
 
         inst_multiple sh shutdown poweroff stty cat ps ln ip dd \
@@ -318,6 +320,9 @@ test_setup() {
 
         inst_simple "${basedir}/modules.d/99base/dracut-lib.sh" "/lib/dracut-lib.sh"
         inst_simple "${basedir}/modules.d/99base/dracut-dev-lib.sh" "/lib/dracut-dev-lib.sh"
+        inst_simple "${basedir}/modules.d/45url-lib/url-lib.sh" "/lib/url-lib.sh"
+        inst_simple "${basedir}/modules.d/40network/net-lib.sh" "/lib/net-lib.sh"
+        inst_simple "${basedir}/modules.d/95nfs/nfs-lib.sh" "/lib/nfs-lib.sh"
         inst_binary "${basedir}/dracut-util" "/usr/bin/dracut-util"
         ln -s dracut-util "${initdir}/usr/bin/dracut-getarg"
         ln -s dracut-util "${initdir}/usr/bin/dracut-getargs"
@@ -368,20 +373,18 @@ test_setup() {
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
     rm -rf -- "$TESTDIR"/server
 
-    dd if=/dev/zero of="$TESTDIR"/server.img bs=1MiB count=80
-    dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/server.img root
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/server.img root 80
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=/dev/dracut/root rw rootfstype=ext4 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd "$TESTDIR"/initramfs.makeroot || return 1
-    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/marker.img || return 1
+    test_marker_check dracut-root-block-created || return 1
 
     # Make an overlay with needed tools for the test harness
     (

--- a/test/TEST-20-NFS/test.sh
+++ b/test/TEST-20-NFS/test.sh
@@ -14,7 +14,7 @@ run_server() {
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/server.img root 0 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/server.img root 0 1
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
@@ -55,8 +55,8 @@ client_test() {
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker2.img marker2 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker2.img marker2 1
     if dhclient --help 2>&1 | grep -q -F -- '--timeout' 2> /dev/null; then
         cmdline="$cmdline rd.net.timeout.dhcp=3"
     fi
@@ -376,8 +376,8 @@ test_setup() {
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/server.img root 80
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/server.img root 80
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \

--- a/test/TEST-20-NFS/test.sh
+++ b/test/TEST-20-NFS/test.sh
@@ -377,7 +377,7 @@ test_setup() {
     # shellcheck disable=SC2034
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/server.img root 80
+    qemu_add_drive disk_index disk_args "$TESTDIR"/server.img root 1
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \

--- a/test/TEST-30-ISCSI/client-init.sh
+++ b/test/TEST-30-ISCSI/client-init.sh
@@ -11,7 +11,7 @@ stty sane
 echo "made it to the rootfs! Powering down."
 while read -r dev _ fstype opts rest || [ -n "$dev" ]; do
     [ "$fstype" != "ext4" ] && continue
-    echo "iscsi-OK $dev $fstype $opts" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+    echo "iscsi-OK $dev $fstype $opts" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
     break
 done < /proc/mounts
 

--- a/test/TEST-30-ISCSI/client-init.sh
+++ b/test/TEST-30-ISCSI/client-init.sh
@@ -10,7 +10,7 @@ export PS1='initramfs-test:\w\$ '
 stty sane
 echo "made it to the rootfs! Powering down."
 while read -r dev _ fstype opts rest || [ -n "$dev" ]; do
-    [ "$fstype" != "ext3" ] && continue
+    [ "$fstype" != "ext4" ] && continue
     echo "iscsi-OK $dev $fstype $opts" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
     break
 done < /proc/mounts

--- a/test/TEST-30-ISCSI/create-client-root.sh
+++ b/test/TEST-30-ISCSI/create-client-root.sh
@@ -12,12 +12,12 @@ udevadm settle
 
 set -ex
 
-mkfs.ext4 -j -L singleroot -F /dev/disk/by-id/ata-disk_singleroot
+mkfs.ext4 -j -L singleroot -F /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_singleroot
 mkdir -p /sysroot
-mount -t ext4 /dev/disk/by-id/ata-disk_singleroot /sysroot
+mount -t ext4 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_singleroot /sysroot
 cp -a -t /sysroot /source/*
 umount /sysroot
-mdadm --create /dev/md0 --run --auto=yes --level=stripe --raid-devices=2 /dev/disk/by-id/ata-disk_raid0-1 /dev/disk/by-id/ata-disk_raid0-2
+mdadm --create /dev/md0 --run --auto=yes --level=stripe --raid-devices=2 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_raid0-1 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_raid0-2
 mdadm -W /dev/md0 || :
 lvm pvcreate -ff -y /dev/md0
 lvm vgcreate dracut /dev/md0
@@ -28,6 +28,6 @@ mount -t ext4 /dev/dracut/root /sysroot
 cp -a -t /sysroot /source/*
 umount /sysroot
 lvm lvchange -a n /dev/dracut/root
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 sync
 poweroff -f

--- a/test/TEST-30-ISCSI/create-client-root.sh
+++ b/test/TEST-30-ISCSI/create-client-root.sh
@@ -12,9 +12,9 @@ udevadm settle
 
 set -ex
 
-mkfs.ext3 -j -L singleroot -F /dev/disk/by-id/ata-disk_singleroot
+mkfs.ext4 -j -L singleroot -F /dev/disk/by-id/ata-disk_singleroot
 mkdir -p /sysroot
-mount /dev/disk/by-id/ata-disk_singleroot /sysroot
+mount -t ext4 /dev/disk/by-id/ata-disk_singleroot /sysroot
 cp -a -t /sysroot /source/*
 umount /sysroot
 mdadm --create /dev/md0 --run --auto=yes --level=stripe --raid-devices=2 /dev/disk/by-id/ata-disk_raid0-1 /dev/disk/by-id/ata-disk_raid0-2
@@ -23,8 +23,8 @@ lvm pvcreate -ff -y /dev/md0
 lvm vgcreate dracut /dev/md0
 lvm lvcreate -l 100%FREE -n root dracut
 lvm vgchange -ay
-mkfs.ext3 -j -L sysroot /dev/dracut/root
-mount /dev/dracut/root /sysroot
+mkfs.ext4 -j -L sysroot /dev/dracut/root
+mount -t ext4 /dev/dracut/root /sysroot
 cp -a -t /sysroot /source/*
 umount /sysroot
 lvm lvchange -a n /dev/dracut/root

--- a/test/TEST-30-ISCSI/create-server-root.sh
+++ b/test/TEST-30-ISCSI/create-server-root.sh
@@ -10,11 +10,11 @@ rm -f -- /etc/lvm/lvm.conf
 udevadm control --reload
 udevadm settle
 
-mkfs.ext4 -L dracut /dev/disk/by-id/ata-disk_root
+mkfs.ext4 -L dracut /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root
 mkdir -p /root
-mount -t ext4 /dev/disk/by-id/ata-disk_root /root
+mount -t ext4 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root /root
 cp -a -t /root /source/*
 mkdir -p /root/run
 umount /root
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-30-ISCSI/create-server-root.sh
+++ b/test/TEST-30-ISCSI/create-server-root.sh
@@ -10,9 +10,9 @@ rm -f -- /etc/lvm/lvm.conf
 udevadm control --reload
 udevadm settle
 
-mkfs.ext3 -L dracut /dev/disk/by-id/ata-disk_root
+mkfs.ext4 -L dracut /dev/disk/by-id/ata-disk_root
 mkdir -p /root
-mount /dev/disk/by-id/ata-disk_root /root
+mount -t ext4 /dev/disk/by-id/ata-disk_root /root
 cp -a -t /root /source/*
 mkdir -p /root/run
 umount /root

--- a/test/TEST-30-ISCSI/server-init.sh
+++ b/test/TEST-30-ISCSI/server-init.sh
@@ -69,9 +69,9 @@ tgtd
 tgtadm --lld iscsi --mode target --op new --tid 1 --targetname iqn.2009-06.dracut:target0
 tgtadm --lld iscsi --mode target --op new --tid 2 --targetname iqn.2009-06.dracut:target1
 tgtadm --lld iscsi --mode target --op new --tid 3 --targetname iqn.2009-06.dracut:target2
-tgtadm --lld iscsi --mode logicalunit --op new --tid 1 --lun 1 -b /dev/disk/by-id/ata-disk_singleroot
-tgtadm --lld iscsi --mode logicalunit --op new --tid 2 --lun 2 -b /dev/disk/by-id/ata-disk_raid0-1
-tgtadm --lld iscsi --mode logicalunit --op new --tid 3 --lun 3 -b /dev/disk/by-id/ata-disk_raid0-2
+tgtadm --lld iscsi --mode logicalunit --op new --tid 1 --lun 1 -b /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_singleroot
+tgtadm --lld iscsi --mode logicalunit --op new --tid 2 --lun 2 -b /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_raid0-1
+tgtadm --lld iscsi --mode logicalunit --op new --tid 3 --lun 3 -b /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_raid0-2
 tgtadm --lld iscsi --mode target --op bind --tid 1 -I 192.168.50.101
 tgtadm --lld iscsi --mode target --op bind --tid 2 -I 192.168.51.101
 tgtadm --lld iscsi --mode target --op bind --tid 3 -I 192.168.50.101

--- a/test/TEST-30-ISCSI/test.sh
+++ b/test/TEST-30-ISCSI/test.sh
@@ -28,7 +28,7 @@ run_server() {
         -net nic,macaddr=52:54:00:12:34:56,model=e1000 \
         -net nic,macaddr=52:54:00:12:34:57,model=e1000 \
         -net socket,listen=127.0.0.1:12330 \
-        -append "panic=1 oops=panic softlockup_panic=1 quiet root=/dev/disk/by-id/ata-disk_serverroot rootfstype=ext3 rw console=ttyS0,115200n81 selinux=0 $SERVER_DEBUG" \
+        -append "panic=1 oops=panic softlockup_panic=1 quiet root=/dev/disk/by-id/ata-disk_serverroot rootfstype=ext4 rw console=ttyS0,115200n81 selinux=0 $SERVER_DEBUG" \
         -initrd "$TESTDIR"/initramfs.server \
         -pidfile "$TESTDIR"/server.pid -daemonize || return 1
     chmod 644 "$TESTDIR"/server.pid || return 1
@@ -171,7 +171,7 @@ test_setup() {
         export initdir=$TESTDIR/overlay
         # shellcheck disable=SC1090
         . "$basedir"/dracut-init.sh
-        inst_multiple sfdisk mkfs.ext3 poweroff cp umount setsid dd sync blockdev
+        inst_multiple sfdisk mkfs.ext4 poweroff cp umount setsid dd sync blockdev
         inst_hook initqueue 01 ./create-client-root.sh
         inst_hook initqueue/finished 01 ./finished-false.sh
     )
@@ -181,7 +181,7 @@ test_setup() {
     # devices, volume groups, encrypted partitions, etc.
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -m "dash crypt lvm mdraid kernel-modules qemu" \
-        -d "piix ide-gd_mod ata_piix ext3 sd_mod" \
+        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
     rm -rf -- "$TESTDIR"/overlay
@@ -201,7 +201,7 @@ test_setup() {
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "root=/dev/fakeroot rw rootfstype=ext3 quiet console=ttyS0,115200n81 selinux=0" \
+        -append "root=/dev/fakeroot rw rootfstype=ext4 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd "$TESTDIR"/initramfs.makeroot || return 1
     grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/marker.img || return 1
     rm -- "$TESTDIR"/marker.img
@@ -262,7 +262,7 @@ test_setup() {
         export initdir=$TESTDIR/overlay
         # shellcheck disable=SC1090
         . "$basedir"/dracut-init.sh
-        inst_multiple sfdisk mkfs.ext3 poweroff cp umount sync dd
+        inst_multiple sfdisk mkfs.ext4 poweroff cp umount sync dd
         inst_hook initqueue 01 ./create-server-root.sh
         inst_hook initqueue/finished 01 ./finished-false.sh
     )
@@ -272,7 +272,7 @@ test_setup() {
     # devices, volume groups, encrypted partitions, etc.
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -m "dash rootfs-block kernel-modules qemu" \
-        -d "piix ide-gd_mod ata_piix ext3 sd_mod" \
+        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         --nomdadmconf \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
@@ -289,7 +289,7 @@ test_setup() {
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "root=/dev/dracut/root rw rootfstype=ext3 quiet console=ttyS0,115200n81 selinux=0" \
+        -append "root=/dev/dracut/root rw rootfstype=ext4 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd "$TESTDIR"/initramfs.makeroot || return 1
     grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/marker.img || return 1
     rm -- "$TESTDIR"/marker.img
@@ -326,7 +326,7 @@ test_setup() {
     # Make server's dracut image
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -a "dash rootfs-block debug kernel-modules network network-legacy" \
-        -d "af_packet piix ide-gd_mod ata_piix ext3 sd_mod e1000 drbg" \
+        -d "af_packet piix ide-gd_mod ata_piix ext4 sd_mod e1000 drbg" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.server "$KVERSION" || return 1
 

--- a/test/TEST-30-ISCSI/test.sh
+++ b/test/TEST-30-ISCSI/test.sh
@@ -185,9 +185,9 @@ test_setup() {
     declare -a disk_args=()
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/singleroot.img singleroot 200
-    qemu_add_drive disk_index disk_args "$TESTDIR"/raid0-1.img raid0-1 100
-    qemu_add_drive disk_index disk_args "$TESTDIR"/raid0-2.img raid0-2 100
+    qemu_add_drive disk_index disk_args "$TESTDIR"/singleroot.img singleroot 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid0-1.img raid0-1 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid0-2.img raid0-2 1
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
@@ -273,7 +273,7 @@ test_setup() {
     # shellcheck disable=SC2034
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/server.img root 240
+    qemu_add_drive disk_index disk_args "$TESTDIR"/server.img root 1
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \

--- a/test/TEST-30-ISCSI/test.sh
+++ b/test/TEST-30-ISCSI/test.sh
@@ -13,10 +13,10 @@ run_server() {
 
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/server.img serverroot 0 1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/singleroot.img singleroot
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid0-1.img raid0-1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid0-2.img raid0-2
+    qemu_add_drive disk_index disk_args "$TESTDIR"/server.img serverroot 0 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/singleroot.img singleroot
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid0-1.img raid0-1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid0-2.img raid0-2
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
@@ -24,7 +24,7 @@ run_server() {
         -net nic,macaddr=52:54:00:12:34:56,model=e1000 \
         -net nic,macaddr=52:54:00:12:34:57,model=e1000 \
         -net socket,listen=127.0.0.1:12330 \
-        -append "panic=1 oops=panic softlockup_panic=1 quiet root=/dev/disk/by-id/ata-disk_serverroot rootfstype=ext4 rw console=ttyS0,115200n81 selinux=0 $SERVER_DEBUG" \
+        -append "panic=1 oops=panic softlockup_panic=1 quiet root=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_serverroot rootfstype=ext4 rw console=ttyS0,115200n81 selinux=0 $SERVER_DEBUG" \
         -initrd "$TESTDIR"/initramfs.server \
         -pidfile "$TESTDIR"/server.pid -daemonize || return 1
     chmod 644 "$TESTDIR"/server.pid || return 1
@@ -53,7 +53,7 @@ run_client() {
 
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
 
     test_marker_reset
     "$testdir"/run-qemu \
@@ -184,10 +184,10 @@ test_setup() {
 
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/singleroot.img singleroot 200
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid0-1.img raid0-1 100
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid0-2.img raid0-2 100
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/singleroot.img singleroot 200
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid0-1.img raid0-1 100
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid0-2.img raid0-2 100
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
@@ -272,8 +272,8 @@ test_setup() {
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/server.img root 60
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/server.img root 240
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
@@ -315,7 +315,7 @@ test_setup() {
     # Make server's dracut image
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -a "dash rootfs-block debug kernel-modules network network-legacy" \
-        -d "af_packet piix ide-gd_mod ata_piix ext4 sd_mod e1000 drbg" \
+        -d "af_packet piix ide-gd_mod ata_piix ext4 sd_mod e1000 drbg virtio_pci virtio_scsi" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.server "$KVERSION" || return 1
 

--- a/test/TEST-30-ISCSI/test.sh
+++ b/test/TEST-30-ISCSI/test.sh
@@ -1,11 +1,7 @@
 #!/bin/bash
 
-[ -z "$USE_NETWORK" ] && USE_NETWORK="network-legacy"
-
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="root filesystem over iSCSI with $USE_NETWORK"
-
-KVERSION=${KVERSION-$(uname -r)}
 
 #DEBUGFAIL="rd.shell rd.break rd.debug loglevel=7 "
 #SERVER_DEBUG="rd.debug loglevel=7"
@@ -17,7 +13,7 @@ run_server() {
 
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/server.img serverroot 1
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/server.img serverroot 0 1
     qemu_add_drive_args disk_index disk_args "$TESTDIR"/singleroot.img singleroot
     qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid0-1.img raid0-1
     qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid0-2.img raid0-2
@@ -55,11 +51,11 @@ run_client() {
     shift
     echo "CLIENT TEST START: $test_name"
 
-    dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
     declare -a disk_args=()
     declare -i disk_index=0
     qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
 
+    test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -net nic,macaddr=52:54:00:12:34:00,model=e1000 \
@@ -70,7 +66,7 @@ run_client() {
         -initrd "$TESTDIR"/initramfs.testing
 
     # shellcheck disable=SC2181
-    if [[ $? -ne 0 ]] || ! grep -U --binary-files=binary -F -m 1 -q iscsi-OK "$TESTDIR"/marker.img; then
+    if [[ $? -ne 0 ]] || ! test_marker_check iscsi-OK; then
         echo "CLIENT TEST END: $test_name [FAILED - BAD EXIT]"
         return 1
     fi
@@ -186,24 +182,19 @@ test_setup() {
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
     rm -rf -- "$TESTDIR"/overlay
 
-    dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
-    dd if=/dev/zero of="$TESTDIR"/singleroot.img bs=1MiB count=200
-    dd if=/dev/zero of="$TESTDIR"/raid0-1.img bs=1MiB count=100
-    dd if=/dev/zero of="$TESTDIR"/raid0-2.img bs=1MiB count=100
-
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/singleroot.img singleroot
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid0-1.img raid0-1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid0-2.img raid0-2
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/singleroot.img singleroot 200
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid0-1.img raid0-1 100
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid0-2.img raid0-2 100
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=/dev/fakeroot rw rootfstype=ext4 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd "$TESTDIR"/initramfs.makeroot || return 1
-    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/marker.img || return 1
+    test_marker_check dracut-root-block-created || return 1
     rm -- "$TESTDIR"/marker.img
 
     # shellcheck disable=SC2031
@@ -278,20 +269,18 @@ test_setup() {
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
     rm -rf -- "$TESTDIR"/overlay
 
-    dd if=/dev/zero of="$TESTDIR"/server.img bs=1MiB count=60
-    dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/server.img root
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/server.img root 60
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=/dev/dracut/root rw rootfstype=ext4 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd "$TESTDIR"/initramfs.makeroot || return 1
-    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/marker.img || return 1
+    test_marker_check dracut-root-block-created || return 1
     rm -- "$TESTDIR"/marker.img
 
     # Make an overlay with needed tools for the test harness

--- a/test/TEST-35-ISCSI-MULTI/client-init.sh
+++ b/test/TEST-35-ISCSI-MULTI/client-init.sh
@@ -11,7 +11,7 @@ stty sane
 echo "made it to the rootfs! Powering down."
 while read -r dev _ fstype opts rest || [ -n "$dev" ]; do
     [ "$fstype" != "ext4" ] && continue
-    echo "iscsi-OK $dev $fstype $opts" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+    echo "iscsi-OK $dev $fstype $opts" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
     break
 done < /proc/mounts
 

--- a/test/TEST-35-ISCSI-MULTI/client-init.sh
+++ b/test/TEST-35-ISCSI-MULTI/client-init.sh
@@ -10,7 +10,7 @@ export PS1='initramfs-test:\w\$ '
 stty sane
 echo "made it to the rootfs! Powering down."
 while read -r dev _ fstype opts rest || [ -n "$dev" ]; do
-    [ "$fstype" != "ext3" ] && continue
+    [ "$fstype" != "ext4" ] && continue
     echo "iscsi-OK $dev $fstype $opts" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
     break
 done < /proc/mounts

--- a/test/TEST-35-ISCSI-MULTI/create-client-root.sh
+++ b/test/TEST-35-ISCSI-MULTI/create-client-root.sh
@@ -12,12 +12,12 @@ udevadm settle
 
 set -ex
 
-mkfs.ext4 -j -L singleroot -F /dev/disk/by-id/ata-disk_singleroot
+mkfs.ext4 -j -L singleroot -F /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_singleroot
 mkdir -p /sysroot
-mount -t ext4 /dev/disk/by-id/ata-disk_singleroot /sysroot
+mount -t ext4 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_singleroot /sysroot
 cp -a -t /sysroot /source/*
 umount /sysroot
-mdadm --create /dev/md0 --run --auto=yes --level=stripe --raid-devices=2 /dev/disk/by-id/ata-disk_raid0-1 /dev/disk/by-id/ata-disk_raid0-2
+mdadm --create /dev/md0 --run --auto=yes --level=stripe --raid-devices=2 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_raid0-1 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_raid0-2
 mdadm -W /dev/md0 || :
 lvm pvcreate -ff -y /dev/md0
 lvm vgcreate dracut /dev/md0
@@ -28,6 +28,6 @@ mount -t ext4 /dev/dracut/root /sysroot
 cp -a -t /sysroot /source/*
 umount /sysroot
 lvm lvchange -a n /dev/dracut/root
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 sync
 poweroff -f

--- a/test/TEST-35-ISCSI-MULTI/create-client-root.sh
+++ b/test/TEST-35-ISCSI-MULTI/create-client-root.sh
@@ -12,9 +12,9 @@ udevadm settle
 
 set -ex
 
-mkfs.ext3 -j -L singleroot -F /dev/disk/by-id/ata-disk_singleroot
+mkfs.ext4 -j -L singleroot -F /dev/disk/by-id/ata-disk_singleroot
 mkdir -p /sysroot
-mount /dev/disk/by-id/ata-disk_singleroot /sysroot
+mount -t ext4 /dev/disk/by-id/ata-disk_singleroot /sysroot
 cp -a -t /sysroot /source/*
 umount /sysroot
 mdadm --create /dev/md0 --run --auto=yes --level=stripe --raid-devices=2 /dev/disk/by-id/ata-disk_raid0-1 /dev/disk/by-id/ata-disk_raid0-2
@@ -23,8 +23,8 @@ lvm pvcreate -ff -y /dev/md0
 lvm vgcreate dracut /dev/md0
 lvm lvcreate -l 100%FREE -n root dracut
 lvm vgchange -ay
-mkfs.ext3 -j -L sysroot /dev/dracut/root
-mount /dev/dracut/root /sysroot
+mkfs.ext4 -j -L sysroot /dev/dracut/root
+mount -t ext4 /dev/dracut/root /sysroot
 cp -a -t /sysroot /source/*
 umount /sysroot
 lvm lvchange -a n /dev/dracut/root

--- a/test/TEST-35-ISCSI-MULTI/create-server-root.sh
+++ b/test/TEST-35-ISCSI-MULTI/create-server-root.sh
@@ -10,11 +10,11 @@ rm -f -- /etc/lvm/lvm.conf
 udevadm control --reload
 udevadm settle
 
-mkfs.ext4 -L dracut /dev/disk/by-id/ata-disk_root
+mkfs.ext4 -L dracut /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root
 mkdir -p /root
-mount -t ext4 /dev/disk/by-id/ata-disk_root /root
+mount -t ext4 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root /root
 cp -a -t /root /source/*
 mkdir -p /root/run
 umount /root
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-35-ISCSI-MULTI/create-server-root.sh
+++ b/test/TEST-35-ISCSI-MULTI/create-server-root.sh
@@ -10,9 +10,9 @@ rm -f -- /etc/lvm/lvm.conf
 udevadm control --reload
 udevadm settle
 
-mkfs.ext3 -L dracut /dev/disk/by-id/ata-disk_root
+mkfs.ext4 -L dracut /dev/disk/by-id/ata-disk_root
 mkdir -p /root
-mount /dev/disk/by-id/ata-disk_root /root
+mount -t ext4 /dev/disk/by-id/ata-disk_root /root
 cp -a -t /root /source/*
 mkdir -p /root/run
 umount /root

--- a/test/TEST-35-ISCSI-MULTI/server-init.sh
+++ b/test/TEST-35-ISCSI-MULTI/server-init.sh
@@ -69,9 +69,9 @@ tgtd
 tgtadm --lld iscsi --mode target --op new --tid 1 --targetname iqn.2009-06.dracut:target0
 tgtadm --lld iscsi --mode target --op new --tid 2 --targetname iqn.2009-06.dracut:target1
 tgtadm --lld iscsi --mode target --op new --tid 3 --targetname iqn.2009-06.dracut:target2
-tgtadm --lld iscsi --mode logicalunit --op new --tid 1 --lun 1 -b /dev/disk/by-id/ata-disk_singleroot
-tgtadm --lld iscsi --mode logicalunit --op new --tid 2 --lun 2 -b /dev/disk/by-id/ata-disk_raid0-1
-tgtadm --lld iscsi --mode logicalunit --op new --tid 3 --lun 3 -b /dev/disk/by-id/ata-disk_raid0-2
+tgtadm --lld iscsi --mode logicalunit --op new --tid 1 --lun 1 -b /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_singleroot
+tgtadm --lld iscsi --mode logicalunit --op new --tid 2 --lun 2 -b /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_raid0-1
+tgtadm --lld iscsi --mode logicalunit --op new --tid 3 --lun 3 -b /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_raid0-2
 tgtadm --lld iscsi --mode target --op bind --tid 1 -I 192.168.50.101
 tgtadm --lld iscsi --mode target --op bind --tid 2 -I 192.168.51.101
 tgtadm --lld iscsi --mode target --op bind --tid 3 -I 192.168.50.101

--- a/test/TEST-35-ISCSI-MULTI/test.sh
+++ b/test/TEST-35-ISCSI-MULTI/test.sh
@@ -28,7 +28,7 @@ run_server() {
         -net nic,macaddr=52:54:00:12:34:56,model=e1000 \
         -net nic,macaddr=52:54:00:12:34:57,model=e1000 \
         -net socket,listen=127.0.0.1:12331 \
-        -append "panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot root=/dev/disk/by-id/ata-disk_serverroot rootfstype=ext3 rw console=ttyS0,115200n81 selinux=0 $SERVER_DEBUG" \
+        -append "panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot root=/dev/disk/by-id/ata-disk_serverroot rootfstype=ext4 rw console=ttyS0,115200n81 selinux=0 $SERVER_DEBUG" \
         -initrd "$TESTDIR"/initramfs.server \
         -pidfile "$TESTDIR"/server.pid -daemonize || return 1
     chmod 644 "$TESTDIR"/server.pid || return 1
@@ -183,7 +183,7 @@ test_setup() {
         export initdir=$TESTDIR/overlay
         # shellcheck disable=SC1090
         . "$basedir"/dracut-init.sh
-        inst_multiple sfdisk mkfs.ext3 poweroff cp umount setsid dd sync blockdev
+        inst_multiple sfdisk mkfs.ext4 poweroff cp umount setsid dd sync blockdev
         inst_hook initqueue 01 ./create-client-root.sh
         inst_hook initqueue/finished 01 ./finished-false.sh
     )
@@ -193,7 +193,7 @@ test_setup() {
     # devices, volume groups, encrypted partitions, etc.
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -m "dash crypt lvm mdraid kernel-modules qemu" \
-        -d "piix ide-gd_mod ata_piix ext3 sd_mod" \
+        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
     rm -rf -- "$TESTDIR"/overlay
@@ -213,7 +213,7 @@ test_setup() {
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "root=/dev/fakeroot rw rootfstype=ext3 quiet console=ttyS0,115200n81 selinux=0" \
+        -append "root=/dev/fakeroot rw rootfstype=ext4 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd "$TESTDIR"/initramfs.makeroot || return 1
     grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/marker.img || return 1
     rm -- "$TESTDIR"/marker.img
@@ -274,7 +274,7 @@ test_setup() {
         export initdir=$TESTDIR/overlay
         # shellcheck disable=SC1090
         . "$basedir"/dracut-init.sh
-        inst_multiple sfdisk mkfs.ext3 poweroff cp umount sync dd
+        inst_multiple sfdisk mkfs.ext4 poweroff cp umount sync dd
         inst_hook initqueue 01 ./create-server-root.sh
         inst_hook initqueue/finished 01 ./finished-false.sh
     )
@@ -284,7 +284,7 @@ test_setup() {
     # devices, volume groups, encrypted partitions, etc.
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -m "dash rootfs-block kernel-modules qemu" \
-        -d "piix ide-gd_mod ata_piix ext3 sd_mod" \
+        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         --nomdadmconf \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
@@ -301,7 +301,7 @@ test_setup() {
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "root=/dev/dracut/root rw rootfstype=ext3 quiet console=ttyS0,115200n81 selinux=0" \
+        -append "root=/dev/dracut/root rw rootfstype=ext4 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd "$TESTDIR"/initramfs.makeroot || return 1
     grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/marker.img || return 1
     rm -- "$TESTDIR"/marker.img
@@ -337,7 +337,7 @@ test_setup() {
     # Make server's dracut image
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -a "dash rootfs-block debug kernel-modules network network-legacy" \
-        -d "af_packet piix ide-gd_mod ata_piix ext3 sd_mod e1000 drbg" \
+        -d "af_packet piix ide-gd_mod ata_piix ext4 sd_mod e1000 drbg" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.server "$KVERSION" || return 1
 

--- a/test/TEST-35-ISCSI-MULTI/test.sh
+++ b/test/TEST-35-ISCSI-MULTI/test.sh
@@ -1,11 +1,7 @@
 #!/bin/bash
 
-[ -z "$USE_NETWORK" ] && USE_NETWORK="network-legacy"
-
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="root filesystem over multiple iSCSI with $USE_NETWORK"
-
-KVERSION=${KVERSION-$(uname -r)}
 
 #DEBUGFAIL="rd.shell rd.break rd.debug loglevel=7 "
 #SERVER_DEBUG="rd.debug loglevel=7"
@@ -17,7 +13,7 @@ run_server() {
 
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/server.img serverroot 1
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/server.img serverroot 0 1
     qemu_add_drive_args disk_index disk_args "$TESTDIR"/singleroot.img singleroot
     qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid0-1.img raid0-1
     qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid0-2.img raid0-2
@@ -54,11 +50,11 @@ run_client() {
     shift
     echo "CLIENT TEST START: $test_name"
 
-    dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
     declare -a disk_args=()
     declare -i disk_index=0
     qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
 
+    test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -net nic,macaddr=52:54:00:12:34:00,model=e1000 \
@@ -66,7 +62,7 @@ run_client() {
         -net socket,connect=127.0.0.1:12331 \
         -append "panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot rw rd.auto rd.retry=50 console=ttyS0,115200n81 selinux=0 rd.debug=0 rd.shell=0 $DEBUGFAIL $*" \
         -initrd "$TESTDIR"/initramfs.testing
-    if ! grep -U --binary-files=binary -F -m 1 -q iscsi-OK "$TESTDIR"/marker.img; then
+    if ! test_marker_check iscsi-OK; then
         echo "CLIENT TEST END: $test_name [FAILED - BAD EXIT]"
         return 1
     fi
@@ -198,24 +194,19 @@ test_setup() {
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
     rm -rf -- "$TESTDIR"/overlay
 
-    dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
-    dd if=/dev/zero of="$TESTDIR"/singleroot.img bs=1MiB count=200
-    dd if=/dev/zero of="$TESTDIR"/raid0-1.img bs=1MiB count=100
-    dd if=/dev/zero of="$TESTDIR"/raid0-2.img bs=1MiB count=100
-
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/singleroot.img singleroot
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid0-1.img raid0-1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid0-2.img raid0-2
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/singleroot.img singleroot 200
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid0-1.img raid0-1 100
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid0-2.img raid0-2 100
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=/dev/fakeroot rw rootfstype=ext4 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd "$TESTDIR"/initramfs.makeroot || return 1
-    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/marker.img || return 1
+    test_marker_check dracut-root-block-created || return 1
     rm -- "$TESTDIR"/marker.img
 
     # shellcheck disable=SC2031
@@ -290,20 +281,18 @@ test_setup() {
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
     rm -rf -- "$TESTDIR"/overlay
 
-    dd if=/dev/zero of="$TESTDIR"/server.img bs=1MiB count=60
-    dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/server.img root
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/server.img root 60
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=/dev/dracut/root rw rootfstype=ext4 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd "$TESTDIR"/initramfs.makeroot || return 1
-    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/marker.img || return 1
+    test_marker_check dracut-root-block-created || return 1
     rm -- "$TESTDIR"/marker.img
 
     # Make an overlay with needed tools for the test harness

--- a/test/TEST-35-ISCSI-MULTI/test.sh
+++ b/test/TEST-35-ISCSI-MULTI/test.sh
@@ -13,10 +13,10 @@ run_server() {
 
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/server.img serverroot 0 1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/singleroot.img singleroot
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid0-1.img raid0-1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid0-2.img raid0-2
+    qemu_add_drive disk_index disk_args "$TESTDIR"/server.img serverroot 0 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/singleroot.img singleroot
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid0-1.img raid0-1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid0-2.img raid0-2
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
@@ -24,7 +24,7 @@ run_server() {
         -net nic,macaddr=52:54:00:12:34:56,model=e1000 \
         -net nic,macaddr=52:54:00:12:34:57,model=e1000 \
         -net socket,listen=127.0.0.1:12331 \
-        -append "panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot root=/dev/disk/by-id/ata-disk_serverroot rootfstype=ext4 rw console=ttyS0,115200n81 selinux=0 $SERVER_DEBUG" \
+        -append "panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot root=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_serverroot rootfstype=ext4 rw console=ttyS0,115200n81 selinux=0 $SERVER_DEBUG" \
         -initrd "$TESTDIR"/initramfs.server \
         -pidfile "$TESTDIR"/server.pid -daemonize || return 1
     chmod 644 "$TESTDIR"/server.pid || return 1
@@ -52,7 +52,7 @@ run_client() {
 
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
 
     test_marker_reset
     "$testdir"/run-qemu \
@@ -196,10 +196,10 @@ test_setup() {
 
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/singleroot.img singleroot 200
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid0-1.img raid0-1 100
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/raid0-2.img raid0-2 100
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/singleroot.img singleroot 200
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid0-1.img raid0-1 100
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid0-2.img raid0-2 100
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
@@ -284,8 +284,8 @@ test_setup() {
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/server.img root 60
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/server.img root 60
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \

--- a/test/TEST-35-ISCSI-MULTI/test.sh
+++ b/test/TEST-35-ISCSI-MULTI/test.sh
@@ -197,9 +197,9 @@ test_setup() {
     declare -a disk_args=()
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/singleroot.img singleroot 200
-    qemu_add_drive disk_index disk_args "$TESTDIR"/raid0-1.img raid0-1 100
-    qemu_add_drive disk_index disk_args "$TESTDIR"/raid0-2.img raid0-2 100
+    qemu_add_drive disk_index disk_args "$TESTDIR"/singleroot.img singleroot 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid0-1.img raid0-1 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/raid0-2.img raid0-2 1
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
@@ -285,7 +285,7 @@ test_setup() {
     # shellcheck disable=SC2034
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/server.img root 60
+    qemu_add_drive disk_index disk_args "$TESTDIR"/server.img root 1
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \

--- a/test/TEST-40-NBD/client-init.sh
+++ b/test/TEST-40-NBD/client-init.sh
@@ -9,7 +9,7 @@ exec > /dev/console 2>&1
 while read -r dev fs fstype opts rest || [ -n "$dev" ]; do
     [ "$dev" = "rootfs" ] && continue
     [ "$fs" != "/" ] && continue
-    echo "nbd-OK $fstype $opts" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+    echo "nbd-OK $fstype $opts" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
     echo "nbd-OK $fstype $opts"
     break
 done < /proc/mounts

--- a/test/TEST-40-NBD/create-client-root.sh
+++ b/test/TEST-40-NBD/create-client-root.sh
@@ -11,14 +11,14 @@ udevadm control --reload
 set -e
 
 udevadm settle
-mkfs.ext4 -L dracut /dev/disk/by-id/ata-disk_root
+mkfs.ext4 -L dracut /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root
 mkdir -p /root
-mount -t ext4 /dev/disk/by-id/ata-disk_root /root
+mount -t ext4 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root /root
 cp -a -t /root /source/*
 mkdir -p /root/run
 umount /root
 {
     echo "dracut-root-block-created"
     echo "ID_FS_UUID=$ID_FS_UUID"
-} | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+} | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 poweroff -f

--- a/test/TEST-40-NBD/create-client-root.sh
+++ b/test/TEST-40-NBD/create-client-root.sh
@@ -11,9 +11,9 @@ udevadm control --reload
 set -e
 
 udevadm settle
-mkfs.ext3 -L dracut /dev/disk/by-id/ata-disk_root
+mkfs.ext4 -L dracut /dev/disk/by-id/ata-disk_root
 mkdir -p /root
-mount /dev/disk/by-id/ata-disk_root /root
+mount -t ext4 /dev/disk/by-id/ata-disk_root /root
 cp -a -t /root /source/*
 mkdir -p /root/run
 umount /root

--- a/test/TEST-40-NBD/create-encrypted-root.sh
+++ b/test/TEST-40-NBD/create-encrypted-root.sh
@@ -13,9 +13,9 @@ udevadm settle
 set -ex
 
 printf test > keyfile
-cryptsetup -q luksFormat /dev/disk/by-id/ata-disk_root /keyfile
+cryptsetup -q luksFormat /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root /keyfile
 echo "The passphrase is test"
-cryptsetup luksOpen /dev/disk/by-id/ata-disk_root dracut_crypt_test < /keyfile
+cryptsetup luksOpen /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root dracut_crypt_test < /keyfile
 lvm pvcreate -ff -y /dev/mapper/dracut_crypt_test
 lvm vgcreate dracut /dev/mapper/dracut_crypt_test
 lvm lvcreate -l 100%FREE -n root dracut
@@ -32,10 +32,10 @@ udevadm settle
 cryptsetup luksClose /dev/mapper/dracut_crypt_test
 udevadm settle
 sleep 1
-eval "$(udevadm info --query=property --name=/dev/disk/by-id/ata-disk_root | while read -r line || [ -n "$line" ]; do [ "$line" != "${line#*ID_FS_UUID*}" ] && echo "$line"; done)"
+eval "$(udevadm info --query=property --name=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root | while read -r line || [ -n "$line" ]; do [ "$line" != "${line#*ID_FS_UUID*}" ] && echo "$line"; done)"
 {
     echo "dracut-root-block-created"
     echo "ID_FS_UUID=$ID_FS_UUID"
-} | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+} | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 sync
 poweroff -f

--- a/test/TEST-40-NBD/create-encrypted-root.sh
+++ b/test/TEST-40-NBD/create-encrypted-root.sh
@@ -21,9 +21,9 @@ lvm vgcreate dracut /dev/mapper/dracut_crypt_test
 lvm lvcreate -l 100%FREE -n root dracut
 lvm vgchange -ay
 udevadm settle
-mkfs.ext3 -L dracut -j /dev/dracut/root
+mkfs.ext4 -L dracut -j /dev/dracut/root
 mkdir -p /sysroot
-mount /dev/dracut/root /sysroot
+mount -t ext4 /dev/dracut/root /sysroot
 cp -a -t /sysroot /source/*
 umount /sysroot
 sleep 1

--- a/test/TEST-40-NBD/create-server-root.sh
+++ b/test/TEST-40-NBD/create-server-root.sh
@@ -12,15 +12,15 @@ udevadm settle
 set -e
 
 udevadm settle
-mkfs.ext4 -L dracut /dev/disk/by-id/ata-disk_root
+mkfs.ext4 -L dracut /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root
 mkdir -p /root
-mount -t ext4 /dev/disk/by-id/ata-disk_root /root
+mount -t ext4 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root /root
 cp -a -t /root /source/*
 mkdir -p /root/run
 umount /root
 {
     echo "dracut-root-block-created"
     echo "ID_FS_UUID=$ID_FS_UUID"
-} | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+} | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 sync
 poweroff -f

--- a/test/TEST-40-NBD/create-server-root.sh
+++ b/test/TEST-40-NBD/create-server-root.sh
@@ -12,9 +12,9 @@ udevadm settle
 set -e
 
 udevadm settle
-mkfs.ext3 -L dracut /dev/disk/by-id/ata-disk_root
+mkfs.ext4 -L dracut /dev/disk/by-id/ata-disk_root
 mkdir -p /root
-mount /dev/disk/by-id/ata-disk_root /root
+mount -t ext4 /dev/disk/by-id/ata-disk_root /root
 cp -a -t /root /source/*
 mkdir -p /root/run
 umount /root

--- a/test/TEST-40-NBD/test.sh
+++ b/test/TEST-40-NBD/test.sh
@@ -29,16 +29,16 @@ run_server() {
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/unencrypted.img unencrypted
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/encrypted.img encrypted
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/server.img serverroot
+    qemu_add_drive disk_index disk_args "$TESTDIR"/unencrypted.img unencrypted
+    qemu_add_drive disk_index disk_args "$TESTDIR"/encrypted.img encrypted
+    qemu_add_drive disk_index disk_args "$TESTDIR"/server.img serverroot
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -serial "${SERIAL:-"file:$TESTDIR/server.log"}" \
         -net nic,macaddr=52:54:00:12:34:56,model=e1000 \
         -net socket,listen=127.0.0.1:12340 \
-        -append "panic=1 oops=panic softlockup_panic=1 rd.luks=0 systemd.crash_reboot quiet root=/dev/disk/by-id/ata-disk_serverroot rootfstype=ext4 rw console=ttyS0,115200n81 selinux=0 $SERVER_DEBUG" \
+        -append "panic=1 oops=panic softlockup_panic=1 rd.luks=0 systemd.crash_reboot quiet root=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_serverroot rootfstype=ext4 rw console=ttyS0,115200n81 selinux=0 $SERVER_DEBUG" \
         -initrd "$TESTDIR"/initramfs.server \
         -pidfile "$TESTDIR"/server.pid -daemonize || return 1
     chmod 644 "$TESTDIR"/server.pid || return 1
@@ -74,7 +74,7 @@ client_test() {
 
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
 
     test_marker_reset
     "$testdir"/run-qemu \
@@ -253,8 +253,8 @@ make_encrypted_root() {
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/encrypted.img root 120
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/encrypted.img root 120
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
@@ -331,8 +331,8 @@ make_client_root() {
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/unencrypted.img root 120
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/unencrypted.img root 120
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
@@ -363,11 +363,11 @@ make_server_root() {
         cat > "$initdir/etc/nbd-server/config" << EOF
 [generic]
 [raw]
-exportname = /dev/disk/by-id/ata-disk_unencrypted
+exportname = /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_unencrypted
 port = 2000
 bs = 4096
 [encrypted]
-exportname = /dev/disk/by-id/ata-disk_encrypted
+exportname = /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_encrypted
 port = 2001
 bs = 4096
 EOF
@@ -428,8 +428,8 @@ EOF
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/server.img root 120
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/server.img root 120
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \

--- a/test/TEST-40-NBD/test.sh
+++ b/test/TEST-40-NBD/test.sh
@@ -1,11 +1,7 @@
 #!/bin/bash
 
-[ -z "$USE_NETWORK" ] && USE_NETWORK="network-legacy"
-
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="root filesystem on NBD with $USE_NETWORK"
-
-KVERSION=${KVERSION-$(uname -r)}
 
 # Uncomment this to debug failures
 # DEBUGFAIL="rd.debug systemd.log_target=console loglevel=7"
@@ -76,11 +72,11 @@ client_test() {
 
     echo "CLIENT TEST START: $test_name"
 
-    dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
     declare -a disk_args=()
     declare -i disk_index=0
     qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
 
+    test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -net nic,macaddr="$mac",model=e1000 \
@@ -89,7 +85,7 @@ client_test() {
         -initrd "$TESTDIR"/initramfs.testing
 
     # shellcheck disable=SC2181
-    if [[ $? -ne 0 ]] || ! grep -U --binary-files=binary -F -m 1 -q nbd-OK "$TESTDIR"/marker.img; then
+    if [[ $? -ne 0 ]] || ! test_marker_check nbd-OK "$TESTDIR"/marker.img; then
         echo "CLIENT TEST END: $test_name [FAILED - BAD EXIT]"
         return 1
     fi
@@ -254,20 +250,18 @@ make_encrypted_root() {
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
     rm -rf -- "$TESTDIR"/overlay
 
-    dd if=/dev/zero of="$TESTDIR"/encrypted.img bs=1MiB count=120
-    dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/encrypted.img root
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/encrypted.img root 120
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=/dev/fakeroot rw quiet console=ttyS0,115200n81 selinux=0" \
         -initrd "$TESTDIR"/initramfs.makeroot || return 1
-    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/marker.img || return 1
+    test_marker_check dracut-root-block-created || return 1
     grep -F -a -m 1 ID_FS_UUID "$TESTDIR"/marker.img > "$TESTDIR"/luks.uuid
 }
 
@@ -334,20 +328,18 @@ make_client_root() {
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
 
-    dd if=/dev/zero of="$TESTDIR"/unencrypted.img bs=1MiB count=120
-    dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/unencrypted.img root
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/unencrypted.img root 120
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=/dev/dracut/root rw rootfstype=ext4 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd "$TESTDIR"/initramfs.makeroot || return 1
-    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/marker.img || return 1
+    test_marker_check dracut-root-block-created || return 1
     rm -fr "$TESTDIR"/overlay
 }
 
@@ -433,20 +425,18 @@ EOF
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
 
-    dd if=/dev/zero of="$TESTDIR"/server.img bs=1MiB count=120
-    dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/server.img root
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/server.img root 120
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=/dev/dracut/root rw rootfstype=ext4 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd "$TESTDIR"/initramfs.makeroot || return 1
-    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/marker.img || return 1
+    test_marker_check dracut-root-block-created || return 1
     rm -fr "$TESTDIR"/overlay
 }
 

--- a/test/TEST-40-NBD/test.sh
+++ b/test/TEST-40-NBD/test.sh
@@ -254,7 +254,7 @@ make_encrypted_root() {
     # shellcheck disable=SC2034
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/encrypted.img root 120
+    qemu_add_drive disk_index disk_args "$TESTDIR"/encrypted.img root 1
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
@@ -332,7 +332,7 @@ make_client_root() {
     # shellcheck disable=SC2034
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/unencrypted.img root 120
+    qemu_add_drive disk_index disk_args "$TESTDIR"/unencrypted.img root 1
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
@@ -429,7 +429,7 @@ EOF
     # shellcheck disable=SC2034
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/server.img root 120
+    qemu_add_drive disk_index disk_args "$TESTDIR"/server.img root 1
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \

--- a/test/TEST-50-MULTINIC/client-init.sh
+++ b/test/TEST-50-MULTINIC/client-init.sh
@@ -31,7 +31,7 @@ done
 {
     echo "OK"
     echo "$IFACES"
-} | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+} | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 
 getargbool 0 rd.shell && sh -i
 

--- a/test/TEST-50-MULTINIC/create-root.sh
+++ b/test/TEST-50-MULTINIC/create-root.sh
@@ -12,12 +12,12 @@ udevadm settle
 
 set -ex
 
-mkfs.ext4 -L dracut /dev/disk/by-id/ata-disk_root
+mkfs.ext4 -L dracut /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root
 mkdir -p /root
-mount -t ext4 /dev/disk/by-id/ata-disk_root /root
+mount -t ext4 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root /root
 cp -a -t /root /source/*
 mkdir -p /root/run
 umount /root
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 sync
 poweroff -f

--- a/test/TEST-50-MULTINIC/create-root.sh
+++ b/test/TEST-50-MULTINIC/create-root.sh
@@ -12,9 +12,9 @@ udevadm settle
 
 set -ex
 
-mkfs.ext3 -L dracut /dev/disk/by-id/ata-disk_root
+mkfs.ext4 -L dracut /dev/disk/by-id/ata-disk_root
 mkdir -p /root
-mount /dev/disk/by-id/ata-disk_root /root
+mount -t ext4 /dev/disk/by-id/ata-disk_root /root
 cp -a -t /root /source/*
 mkdir -p /root/run
 umount /root

--- a/test/TEST-50-MULTINIC/test.sh
+++ b/test/TEST-50-MULTINIC/test.sh
@@ -1,11 +1,7 @@
 #!/bin/bash
 
-[ -z "$USE_NETWORK" ] && USE_NETWORK="network-legacy"
-
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="root filesystem on NFS with multiple nics with $USE_NETWORK"
-
-KVERSION=${KVERSION-$(uname -r)}
 
 # Uncomment this to debug failures
 #DEBUGFAIL="loglevel=7 rd.shell rd.break"
@@ -58,7 +54,6 @@ client_test() {
 
     echo "CLIENT TEST START: $test_name"
 
-    dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
@@ -69,6 +64,7 @@ client_test() {
     fi
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
+    test_marker_reset
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -net socket,connect=127.0.0.1:12350 \
@@ -315,20 +311,18 @@ test_setup() {
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
     rm -rf -- "$TESTDIR"/overlay
 
-    dd if=/dev/zero of="$TESTDIR"/server.img bs=1MiB count=120
-    dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/server.img root
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/server.img root 120
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
         -append "root=/dev/dracut/root rw rootfstype=ext4 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd "$TESTDIR"/initramfs.makeroot || return 1
-    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/marker.img || return 1
+    test_marker_check dracut-root-block-created || return 1
 
     # Make an overlay with needed tools for the test harness
     (

--- a/test/TEST-50-MULTINIC/test.sh
+++ b/test/TEST-50-MULTINIC/test.sh
@@ -14,7 +14,7 @@ run_server() {
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/server.img root
+    qemu_add_drive disk_index disk_args "$TESTDIR"/server.img root
 
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
@@ -57,7 +57,7 @@ client_test() {
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker
 
     if dhclient --help 2>&1 | grep -q -F -- '--timeout' 2> /dev/null; then
         cmdline="$cmdline rd.net.timeout.dhcp=3"
@@ -314,8 +314,8 @@ test_setup() {
     declare -a disk_args=()
     # shellcheck disable=SC2034
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/server.img root 120
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/server.img root 120
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \

--- a/test/TEST-50-MULTINIC/test.sh
+++ b/test/TEST-50-MULTINIC/test.sh
@@ -26,7 +26,7 @@ run_server() {
         -net nic,macaddr=52:54:01:12:34:56,model=e1000 \
         -serial "${SERIAL:-"file:$TESTDIR/server.log"}" \
         -device i6300esb -watchdog-action poweroff \
-        -append "panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot root=LABEL=dracut rootfstype=ext3 rw console=ttyS0,115200n81 selinux=0" \
+        -append "panic=1 oops=panic softlockup_panic=1 systemd.crash_reboot root=LABEL=dracut rootfstype=ext4 rw console=ttyS0,115200n81 selinux=0" \
         -initrd "$TESTDIR"/initramfs.server \
         -pidfile "$TESTDIR"/server.pid -daemonize || return 1
 
@@ -299,7 +299,7 @@ test_setup() {
         export initdir=$TESTDIR/overlay
         # shellcheck disable=SC1090
         . "$basedir"/dracut-init.sh
-        inst_multiple sfdisk mkfs.ext3 poweroff cp umount sync dd
+        inst_multiple sfdisk mkfs.ext4 poweroff cp umount sync dd
         inst_hook initqueue 01 ./create-root.sh
         inst_hook initqueue/finished 01 ./finished-false.sh
     )
@@ -309,7 +309,7 @@ test_setup() {
     # devices, volume groups, encrypted partitions, etc.
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -m "bash rootfs-block kernel-modules qemu" \
-        -d "piix ide-gd_mod ata_piix ext3 sd_mod" \
+        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         --nomdadmconf \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
@@ -326,7 +326,7 @@ test_setup() {
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
         "${disk_args[@]}" \
-        -append "root=/dev/dracut/root rw rootfstype=ext3 quiet console=ttyS0,115200n81 selinux=0" \
+        -append "root=/dev/dracut/root rw rootfstype=ext4 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd "$TESTDIR"/initramfs.makeroot || return 1
     grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/marker.img || return 1
 
@@ -365,7 +365,7 @@ test_setup() {
     # Make server's dracut image
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -m "dash rootfs-block debug kernel-modules watchdog qemu network network-legacy" \
-        -d "af_packet piix ide-gd_mod ata_piix ext3 sd_mod nfsv2 nfsv3 nfsv4 nfs_acl nfs_layout_nfsv41_files nfsd e1000 i6300esb ib700wdt" \
+        -d "af_packet piix ide-gd_mod ata_piix ext4 sd_mod nfsv2 nfsv3 nfsv4 nfs_acl nfs_layout_nfsv41_files nfsd e1000 i6300esb ib700wdt" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.server "$KVERSION" || return 1
 

--- a/test/TEST-50-MULTINIC/test.sh
+++ b/test/TEST-50-MULTINIC/test.sh
@@ -315,7 +315,7 @@ test_setup() {
     # shellcheck disable=SC2034
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/server.img root 120
+    qemu_add_drive disk_index disk_args "$TESTDIR"/server.img root 1
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \

--- a/test/TEST-60-BONDBRIDGEVLANIFCFG/create-root.sh
+++ b/test/TEST-60-BONDBRIDGEVLANIFCFG/create-root.sh
@@ -11,12 +11,12 @@ udevadm control --reload
 udevadm settle
 set -e
 
-mkfs.ext4 -L dracut /dev/disk/by-id/ata-disk_root
+mkfs.ext4 -L dracut /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root
 mkdir -p /root
-mount -t ext4 /dev/disk/by-id/ata-disk_root /root
+mount -t ext4 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_root /root
 cp -a -t /root /source/*
 mkdir -p /root/run
 umount /root
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
+echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_marker
 sync
 poweroff -f

--- a/test/TEST-60-BONDBRIDGEVLANIFCFG/create-root.sh
+++ b/test/TEST-60-BONDBRIDGEVLANIFCFG/create-root.sh
@@ -17,9 +17,9 @@ sfdisk /dev/sda << EOF
 EOF
 
 udevadm settle
-mkfs.ext3 -L dracut /dev/sda2
+mkfs.ext4 -L dracut /dev/sda2
 mkdir -p /root
-mount /dev/sda2 /root
+mount -t ext4 /dev/sda2 /root
 cp -a -t /root /source/*
 mkdir -p /root/run
 umount /root

--- a/test/TEST-60-BONDBRIDGEVLANIFCFG/create-root.sh
+++ b/test/TEST-60-BONDBRIDGEVLANIFCFG/create-root.sh
@@ -10,19 +10,13 @@ rm -f -- /etc/lvm/lvm.conf
 udevadm control --reload
 udevadm settle
 set -e
-# save a partition at the beginning for future flagging purposes
-sfdisk /dev/sda << EOF
-,1M
-,
-EOF
 
-udevadm settle
-mkfs.ext4 -L dracut /dev/sda2
+mkfs.ext4 -L dracut /dev/disk/by-id/ata-disk_root
 mkdir -p /root
-mount -t ext4 /dev/sda2 /root
+mount -t ext4 /dev/disk/by-id/ata-disk_root /root
 cp -a -t /root /source/*
 mkdir -p /root/run
 umount /root
-echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/sda1
+echo "dracut-root-block-created" | dd oflag=direct,dsync of=/dev/disk/by-id/ata-disk_marker
 sync
 poweroff -f

--- a/test/TEST-60-BONDBRIDGEVLANIFCFG/test.sh
+++ b/test/TEST-60-BONDBRIDGEVLANIFCFG/test.sh
@@ -2,12 +2,8 @@
 # -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
 # ex: ts=8 sw=4 sts=4 et filetype=sh
 
-[ -z "$USE_NETWORK" ] && USE_NETWORK="network-legacy"
-
 # shellcheck disable=SC2034
 TEST_DESCRIPTION="root filesystem on NFS with bridging/bonding/vlan with $USE_NETWORK"
-
-KVERSION=${KVERSION-$(uname -r)}
 
 # Uncomment this to debug failures
 #DEBUGFAIL="rd.shell rd.break"
@@ -201,9 +197,6 @@ root=nfs:192.168.50.1:/nfs/client bootdev=br0
 }
 
 test_setup() {
-    # Make server root
-    dd if=/dev/zero of="$TESTDIR"/server.ext4 bs=1M count=120
-
     kernel=$KVERSION
     rm -rf -- "$TESTDIR"/overlay
     (
@@ -341,12 +334,18 @@ test_setup() {
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
 
+    declare -a disk_args=()
+    declare -i disk_index=0
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive_args disk_index disk_args "$TESTDIR"/server.ext4 root 120
+
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
-        -drive format=raw,index=0,media=disk,file="$TESTDIR"/server.ext4 \
+        "${disk_args[@]}" \
         -append "root=/dev/dracut/root rw rootfstype=ext4 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd "$TESTDIR"/initramfs.makeroot || return 1
-    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/server.ext4 || return 1
+    test_marker_check dracut-root-block-created || return 1
+    rm -- "$TESTDIR"/marker.img
     rm -fr "$TESTDIR"/overlay
 
     # Make an overlay with needed tools for the test harness

--- a/test/TEST-60-BONDBRIDGEVLANIFCFG/test.sh
+++ b/test/TEST-60-BONDBRIDGEVLANIFCFG/test.sh
@@ -336,8 +336,8 @@ test_setup() {
 
     declare -a disk_args=()
     declare -i disk_index=0
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive_args disk_index disk_args "$TESTDIR"/server.ext4 root 120
+    qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
+    qemu_add_drive disk_index disk_args "$TESTDIR"/server.ext4 root 120
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \

--- a/test/TEST-60-BONDBRIDGEVLANIFCFG/test.sh
+++ b/test/TEST-60-BONDBRIDGEVLANIFCFG/test.sh
@@ -337,7 +337,7 @@ test_setup() {
     declare -a disk_args=()
     declare -i disk_index=0
     qemu_add_drive disk_index disk_args "$TESTDIR"/marker.img marker 1
-    qemu_add_drive disk_index disk_args "$TESTDIR"/server.ext4 root 120
+    qemu_add_drive disk_index disk_args "$TESTDIR"/server.ext4 root 1
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \

--- a/test/TEST-60-BONDBRIDGEVLANIFCFG/test.sh
+++ b/test/TEST-60-BONDBRIDGEVLANIFCFG/test.sh
@@ -27,10 +27,10 @@ run_server() {
         -device virtio-net-pci,netdev=n1,mac=52:54:01:12:34:57 \
         -device virtio-net-pci,netdev=n2,mac=52:54:01:12:34:58 \
         -device virtio-net-pci,netdev=n3,mac=52:54:01:12:34:59 \
-        -hda "$TESTDIR"/server.ext3 \
+        -hda "$TESTDIR"/server.ext4 \
         -serial "${SERIAL:-"file:$TESTDIR/server.log"}" \
         -device i6300esb -watchdog-action poweroff \
-        -append "panic=1 oops=panic softlockup_panic=1 loglevel=7 root=LABEL=dracut rootfstype=ext3 rw console=ttyS0,115200n81 selinux=0 rd.debug" \
+        -append "panic=1 oops=panic softlockup_panic=1 loglevel=7 root=LABEL=dracut rootfstype=ext4 rw console=ttyS0,115200n81 selinux=0 rd.debug" \
         -initrd "$TESTDIR"/initramfs.server \
         -pidfile "$TESTDIR"/server.pid -daemonize || return 1
     chmod 644 -- "$TESTDIR"/server.pid || return 1
@@ -202,7 +202,7 @@ root=nfs:192.168.50.1:/nfs/client bootdev=br0
 
 test_setup() {
     # Make server root
-    dd if=/dev/zero of="$TESTDIR"/server.ext3 bs=1M count=120
+    dd if=/dev/zero of="$TESTDIR"/server.ext4 bs=1M count=120
 
     kernel=$KVERSION
     rm -rf -- "$TESTDIR"/overlay
@@ -326,7 +326,7 @@ test_setup() {
         export initdir=$TESTDIR/overlay
         # shellcheck disable=SC1090
         . "$basedir"/dracut-init.sh
-        inst_multiple sfdisk mkfs.ext3 poweroff cp umount sync dd
+        inst_multiple sfdisk mkfs.ext4 poweroff cp umount sync dd
         inst_hook initqueue 01 ./create-root.sh
         inst_hook initqueue/finished 01 ./finished-false.sh
     )
@@ -336,17 +336,17 @@ test_setup() {
     # devices, volume groups, encrypted partitions, etc.
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         -m "bash rootfs-block kernel-modules qemu" \
-        -d "piix ide-gd_mod ata_piix ext3 sd_mod" \
+        -d "piix ide-gd_mod ata_piix ext4 sd_mod" \
         --nomdadmconf \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.makeroot "$KVERSION" || return 1
 
     # Invoke KVM and/or QEMU to actually create the target filesystem.
     "$testdir"/run-qemu \
-        -drive format=raw,index=0,media=disk,file="$TESTDIR"/server.ext3 \
-        -append "root=/dev/dracut/root rw rootfstype=ext3 quiet console=ttyS0,115200n81 selinux=0" \
+        -drive format=raw,index=0,media=disk,file="$TESTDIR"/server.ext4 \
+        -append "root=/dev/dracut/root rw rootfstype=ext4 quiet console=ttyS0,115200n81 selinux=0" \
         -initrd "$TESTDIR"/initramfs.makeroot || return 1
-    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/server.ext3 || return 1
+    grep -U --binary-files=binary -F -m 1 -q dracut-root-block-created "$TESTDIR"/server.ext4 || return 1
     rm -fr "$TESTDIR"/overlay
 
     # Make an overlay with needed tools for the test harness
@@ -380,7 +380,7 @@ test_setup() {
     "$basedir"/dracut.sh -l -i "$TESTDIR"/overlay / \
         --no-early-microcode \
         -m "rootfs-block debug kernel-modules watchdog qemu network network-legacy" \
-        -d "ipvlan macvlan af_packet piix ide-gd_mod ata_piix ext3 sd_mod nfsv2 nfsv3 nfsv4 nfs_acl nfs_layout_nfsv41_files nfsd virtio-net i6300esb ib700wdt" \
+        -d "ipvlan macvlan af_packet piix ide-gd_mod ata_piix ext4 sd_mod nfsv2 nfsv3 nfsv4 nfs_acl nfs_layout_nfsv41_files nfsd virtio-net i6300esb ib700wdt" \
         --no-hostonly-cmdline -N \
         -f "$TESTDIR"/initramfs.server "$KVERSION" || return 1
 }

--- a/test/run-qemu
+++ b/test/run-qemu
@@ -20,7 +20,7 @@ QEMU_CPU="${QEMU_CPU:-max}"
 }
 
 # Provide rng device sourcing the hosts /dev/urandom and other standard parameters
-ARGS+=(-M q35 -smp 2 -m 512 -nodefaults -vga none -display none -no-reboot -device virtio-rng-pci)
+ARGS+=(-M q35 -smp 2 -m 1024 -nodefaults -vga none -display none -no-reboot -device virtio-rng-pci)
 
 if ! [[ $* == *-daemonize* ]] && ! [[ $* == *-daemonize* ]]; then
     ARGS+=(-serial stdio)

--- a/test/test-functions
+++ b/test/test-functions
@@ -10,6 +10,10 @@ fi
 echo "TESTDIR=\"$TESTDIR\"" > .testdir${TEST_RUN_ID:+-$TEST_RUN_ID}
 export TESTDIR
 
+KVERSION=${KVERSION-$(uname -r)}
+
+[ -z "$USE_NETWORK" ] && USE_NETWORK="network-legacy"
+
 if [[ -z $basedir ]]; then basedir="$(realpath ../..)"; fi
 
 command -v test_check &> /dev/null || test_check() {
@@ -47,6 +51,7 @@ check_root() {
 # args: name of the argument array variable (set to () at start)
 # filename: filename of the raw disk image
 # id-name: name of the disk in /dev/disk/by-id -> /dev/disk/by-id/ata-disk_$name
+# size: optional file size in MiB (0 implies size is not set)
 # bootindex: optional bootindex number
 #
 # to be used later with `qemu … "${args[@]}" …`
@@ -58,7 +63,7 @@ check_root() {
 # ```
 #   declare -a disk_args=()
 #   declare -i disk_index=0
-#   qemu_add_drive_args disk_index disk_args "$TESTDIR"/root.ext3 root 1
+#   qemu_add_drive_args disk_index disk_args "$TESTDIR"/root.ext3 root 0 1
 #   qemu_add_drive_args disk_index disk_args "$TESTDIR"/client.img client
 #   qemu_add_drive_args disk_index disk_args "$TESTDIR"/iscsidisk2.img iscsidisk2
 #   qemu_add_drive_args disk_index disk_args "$TESTDIR"/iscsidisk3.img iscsidisk3
@@ -68,7 +73,12 @@ qemu_add_drive_args() {
     local index=${!1}
     local file=$3
     local name=${4:-$index}
-    local bootindex=$5
+    local size=${5:-0}
+    local bootindex=$6
+
+    if [ "${size}" -ne 0 ]; then
+        dd if=/dev/zero of="${file}" bs=1MiB count="${size}"
+    fi
 
     eval "${2}"'+=(' \
         -drive "if=none,format=raw,file=${file},id=drive-sata${index}" \
@@ -77,6 +87,18 @@ qemu_add_drive_args() {
 
     # shellcheck disable=SC2219
     let "${1}++"
+}
+
+test_marker_reset() {
+    dd if=/dev/zero of="$TESTDIR"/marker.img bs=1MiB count=1
+}
+
+test_marker_check() {
+    local marker=${1:-dracut-root-block-success}
+    local file=${2:-marker.img}
+
+    grep -U --binary-files=binary -F -m 1 -q "$marker" "$TESTDIR/$file"
+    return $?
 }
 
 while (($# > 0)); do

--- a/test/test-functions
+++ b/test/test-functions
@@ -51,7 +51,7 @@ check_root() {
 # args: name of the argument array variable (set to () at start)
 # filename: filename of the raw disk image
 # id-name: name of the disk in /dev/disk/by-id -> /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_$name
-# size: optional file size in MiB (0 implies size is not set)
+# size: optional boolean to initialize the drive
 # bootindex: optional bootindex number
 #
 # to be used later with `qemu … "${args[@]}" …`
@@ -77,6 +77,12 @@ qemu_add_drive() {
     local bootindex=$6
 
     if [ "${size}" -ne 0 ]; then
+        if [[ ${name} =~ "marker" ]]; then
+            size=1
+        else
+            size=512
+        fi
+
         dd if=/dev/zero of="${file}" bs=1MiB count="${size}"
     fi
 

--- a/test/test-functions
+++ b/test/test-functions
@@ -43,9 +43,30 @@ check_root() {
     fi
 }
 
+# obsolete - use qemu_add_drive
+qemu_add_drive_args() {
+    local index=${!1}
+    local file=$3
+    local name=${4:-$index}
+    local size=${5:-0}
+    local bootindex=$6
+
+    if [ "${size}" -ne 0 ]; then
+        dd if=/dev/zero of="${file}" bs=1MiB count="${size}"
+    fi
+
+    eval "${2}"'+=(' \
+        -drive "if=none,format=raw,file=${file},id=drive-sata${index}" \
+        -device "ide-hd,bus=ide.${index},drive=drive-sata${index},id=sata${index},${bootindex:+bootindex=$bootindex,}model=disk,serial=${name}" \
+        ')'
+
+    # shellcheck disable=SC2219
+    let "${1}++"
+}
+
 # generate qemu arguments for named raw disks
 #
-# qemu_add_drive_args <index> <args> <filename> <id-name> [<bootindex>]
+# qemu_add_drive <index> <args> <filename> <id-name> [<bootindex>]
 #
 # index: name of the index variable (set to 0 at start)
 # args: name of the argument array variable (set to () at start)
@@ -63,13 +84,13 @@ check_root() {
 # ```
 #   declare -a disk_args=()
 #   declare -i disk_index=0
-#   qemu_add_drive_args disk_index disk_args "$TESTDIR"/root.ext3 root 0 1
-#   qemu_add_drive_args disk_index disk_args "$TESTDIR"/client.img client
-#   qemu_add_drive_args disk_index disk_args "$TESTDIR"/iscsidisk2.img iscsidisk2
-#   qemu_add_drive_args disk_index disk_args "$TESTDIR"/iscsidisk3.img iscsidisk3
+#   qemu_add_drive disk_index disk_args "$TESTDIR"/root.ext3 root 0 1
+#   qemu_add_drive disk_index disk_args "$TESTDIR"/client.img client
+#   qemu_add_drive disk_index disk_args "$TESTDIR"/iscsidisk2.img iscsidisk2
+#   qemu_add_drive disk_index disk_args "$TESTDIR"/iscsidisk3.img iscsidisk3
 #   qemu "${disk_args[@]}"
 # ```
-qemu_add_drive_args() {
+qemu_add_drive() {
     local index=${!1}
     local file=$3
     local name=${4:-$index}
@@ -81,8 +102,9 @@ qemu_add_drive_args() {
     fi
 
     eval "${2}"'+=(' \
-        -drive "if=none,format=raw,file=${file},id=drive-sata${index}" \
-        -device "ide-hd,bus=ide.${index},drive=drive-sata${index},id=sata${index},${bootindex:+bootindex=$bootindex,}model=disk,serial=${name}" \
+        -device "virtio-scsi-pci,id=scsi${index}" \
+        -drive "if=none,format=raw,file=${file},id=drive-data${index}" \
+        -device "scsi-hd,bus=scsi${index}.0,drive=drive-data${index},id=data${index},${bootindex:+bootindex=$bootindex,}serial=${name}" \
         ')'
 
     # shellcheck disable=SC2219

--- a/test/test-functions
+++ b/test/test-functions
@@ -43,27 +43,6 @@ check_root() {
     fi
 }
 
-# obsolete - use qemu_add_drive
-qemu_add_drive_args() {
-    local index=${!1}
-    local file=$3
-    local name=${4:-$index}
-    local size=${5:-0}
-    local bootindex=$6
-
-    if [ "${size}" -ne 0 ]; then
-        dd if=/dev/zero of="${file}" bs=1MiB count="${size}"
-    fi
-
-    eval "${2}"'+=(' \
-        -drive "if=none,format=raw,file=${file},id=drive-sata${index}" \
-        -device "ide-hd,bus=ide.${index},drive=drive-sata${index},id=sata${index},${bootindex:+bootindex=$bootindex,}model=disk,serial=${name}" \
-        ')'
-
-    # shellcheck disable=SC2219
-    let "${1}++"
-}
-
 # generate qemu arguments for named raw disks
 #
 # qemu_add_drive <index> <args> <filename> <id-name> [<bootindex>]
@@ -71,7 +50,7 @@ qemu_add_drive_args() {
 # index: name of the index variable (set to 0 at start)
 # args: name of the argument array variable (set to () at start)
 # filename: filename of the raw disk image
-# id-name: name of the disk in /dev/disk/by-id -> /dev/disk/by-id/ata-disk_$name
+# id-name: name of the disk in /dev/disk/by-id -> /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_$name
 # size: optional file size in MiB (0 implies size is not set)
 # bootindex: optional bootindex number
 #


### PR DESCRIPTION
Main issue: since systemd-v256, `libkmod` is dlopened (https://github.com/systemd/systemd/commit/3abc3671f56d0d124c93acef20f7e7a1c8efe72b), which is not a real problem for real installations because the systemd module was fixed at that point (https://github.com/dracut-ng/dracut-ng/commit/04b362d713235459cff1f370efb4cd5e36e4a358), but it's an issue for the testsuite, because usually tests create initrds only including some dracut modules with `-m`, `udev-rules` is always required, it installs `systemd-udevd`, and `libkmod` was not being installed, hence the failures.

Also `TEST-04-FULL-SYSTEMD` was flaky. The cause was the same defined in [boo#1218710](https://bugzilla.opensuse.org/show_bug.cgi?id=1218710): `systemd-vconsole-setup.service` sometimes fails due to a timing issue where the virtual console is not ready when systemd tries to set fonts using `loadkeys`. So, do not consider that an error in the testsuite. 

Finally, backported some upstream patches to modernize the testsuite a bit.
