### PR TITLE
fix(fips): handle zipl (bsc#1262515) (SLES-16.0:Update)

### DIFF
--- a/modules.d/01fips/fips-lib.sh
+++ b/modules.d/01fips/fips-lib.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+get_vmname() {
+    local _vmname
+
+    case "$(uname -m)" in
+    s390|s390x)
+        _vmname=image
+        ;;
+    ppc*)
+        _vmname=vmlinux
+        ;;
+    aarch64)
+        _vmname=Image
+        ;;
+    armv*)
+        _vmname=zImage
+        ;;
+    *)
+        _vmname=vmlinuz
+        ;;
+    esac
+
+    echo "$_vmname"
+}

--- a/modules.d/01fips/fips.sh
+++ b/modules.d/01fips/fips.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+command -v getarg > /dev/null || . /lib/dracut-lib.sh
+command -v get_vmname > /dev/null || . /lib/fips-lib.sh
+
 # find fipscheck, prefer kernel-based version
 fipscheck()
 {
@@ -15,8 +18,6 @@ fipscheck()
     fi
     echo $FIPSCHECK
 }
-
-type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
 
 # systemd lets stdout go to journal only, but the system
 # has to halt when the integrity check fails to satisfy FIPS.
@@ -82,6 +83,47 @@ mount_boot() {
     fi
 }
 
+mount_zipl() {
+    boot=$(getarg rd.zipl=)
+
+    if [ -d /boot/zipl ] && ismounted /boot/zipl; then
+        fips_info "Nothing to do, /boot/zipl is already mounted..."
+        return 0
+    fi
+    if [ -z "$boot" ]; then
+        die "You have to specify rd.zipl=<boot device> as a boot option for fips=1"
+    fi
+    case "$boot" in
+        LABEL=* | UUID=* | PARTUUID=* | PARTLABEL=*)
+            boot="$(label_uuid_to_dev "$boot")"
+            ;;
+        /dev/*) ;;
+
+        *)
+            die "You have to specify rd.zipl=<boot device> as a boot option for fips=1"
+            ;;
+    esac
+    if ! [ -e "$boot" ]; then
+        udevadm trigger --action=add > /dev/null 2>&1
+
+        i=0
+        while ! [ -e "$boot" ]; do
+            udevadm settle --exit-if-exists="$boot"
+            [ -e "$boot" ] && break
+            sleep 0.5
+            i=$((i + 1))
+            [ $i -gt 40 ] && break
+        done
+    fi
+
+    [ -e "$boot" ] || die "$boot: no such device"
+
+    mkdir -p /boot/zipl || die "Couldn't create mount point for /boot/zipl"
+    fips_info "Mounting $boot as /boot/zipl"
+    mount -oro "$boot" /boot/zipl || die "Couldn't mount $boot"
+    FIPS_MOUNTED_ZIPL=1
+}
+
 do_rhevh_check() {
     KERNEL=$(uname -r)
     kpath=${1}
@@ -102,30 +144,6 @@ nonfatal_modprobe() {
         | while read -r line || [ -n "$line" ]; do
             echo "${line#modprobe: FATAL: }" >&2
         done
-}
-
-get_vmname() {
-    local _vmname
-
-    case "$(uname -m)" in
-    s390|s390x)
-        _vmname=image
-        ;;
-    ppc*)
-        _vmname=vmlinux
-        ;;
-    aarch64)
-        _vmname=Image
-        ;;
-    armv*)
-        _vmname=zImage
-        ;;
-    *)
-        _vmname=vmlinuz
-        ;;
-    esac
-
-    echo "$_vmname"
 }
 
 fips_load_crypto() {
@@ -183,6 +201,9 @@ fips_load_crypto() {
 
 do_fips() {
     KERNEL=$(uname -r)
+    #FIXME: "lib64" might be wrong, but (for now) it's vital only for s390x => good enough
+    # (and a symlink from "lib" exists)
+    FIPSCHECKDIR=/usr/lib64/fipscheck
 
     if ! getarg rd.fips.skipkernel > /dev/null; then
 
@@ -209,6 +230,11 @@ do_fips() {
 
             if [ -z "$BOOT_IMAGE_NAME" ]; then
                 BOOT_IMAGE_NAME="${_vmname}-${KERNEL}"
+                if getargbool 0 initgrub; then
+                    # only needed for zipl booted first stage
+                   mount_zipl
+                   BOOT_IMAGE_PATH=zipl/
+                fi
             elif ! [ -e "/boot/${BOOT_IMAGE_PATH}/${BOOT_IMAGE}" ]; then
                 #if /boot is not a separate partition BOOT_IMAGE might start with /boot
                 BOOT_IMAGE_PATH=${BOOT_IMAGE_PATH#"/boot"}
@@ -220,10 +246,15 @@ do_fips() {
                 fi
             fi
 
-            BOOT_IMAGE_HMAC="/boot/${BOOT_IMAGE_PATH}/.${BOOT_IMAGE_NAME}.hmac"
+            BOOT_IMAGE_HMAC="/boot/${BOOT_IMAGE_PATH}.${BOOT_IMAGE_NAME}.hmac"
             if ! [ -e "${BOOT_IMAGE_HMAC}" ]; then
-                warn "${BOOT_IMAGE_HMAC} does not exist"
-                return 1
+                FCDBIH="${FIPSCHECKDIR}/${_vmname}-${KERNEL}.hmac"
+                if [ -r "${FCDBIH}" ]; then
+                    BOOT_IMAGE_HMAC="${FCDBIH}"
+                else
+                    warn "${BOOT_IMAGE_HMAC} does not exist"
+                    return 1
+                fi
             fi
 
             BOOT_IMAGE_KERNEL="/boot/${BOOT_IMAGE_PATH}${BOOT_IMAGE_NAME}"
@@ -231,6 +262,12 @@ do_fips() {
                 warn "${BOOT_IMAGE_KERNEL} does not exist"
                 return 1
             fi
+
+            # kernel-based fipscheck doesn't respect it's man-page...
+            ln -s  "${BOOT_IMAGE_KERNEL}" "/${_vmname}-${KERNEL}"
+            ln -sf "${BOOT_IMAGE_HMAC}"   "/.${_vmname}-${KERNEL}.hmac"
+            # so base the checks on sym-links in /
+            BOOT_IMAGE_KERNEL="/${_vmname}-${KERNEL}"
 
             if [ -n "$(fipscheck)" ]; then
                 $(fipscheck) "${BOOT_IMAGE_KERNEL}" || return 1
@@ -250,6 +287,10 @@ do_fips() {
         umount /boot > /dev/null 2>&1
     else
         fips_info "Not unmounting /boot"
+    fi
+    if [ "$FIPS_MOUNTED_ZIPL" = 1 ]; then
+        fips_info "Unmounting /boot/zipl"
+        umount /boot/zipl > /dev/null 2>&1
     fi
 
     return 0

--- a/modules.d/01fips/module-setup.sh
+++ b/modules.d/01fips/module-setup.sh
@@ -13,7 +13,7 @@ depends() {
 
 # called by dracut
 installkernel() {
-    local _fipsmodules _mod _bootfstype
+    local _fipsmodules _mod _bootfstype _vmname _fipscheckdir
     if [[ -f "${srcmods}/modules.fips" ]]; then
         read -d '' -r _fipsmodules < "${srcmods}/modules.fips"
     else
@@ -60,6 +60,18 @@ installkernel() {
             dwarning "Can't determine fs type for /boot, FIPS check may fail."
         fi
     fi
+
+    # shellcheck source=fips-lib.sh
+    . "$moddir/fips-lib.sh"
+    _vmname=$(get_vmname)
+    if [[ -e "${srcmods}/.${_vmname}.hmac" ]]; then
+        _fipscheckdir="${initdir}/usr/lib64/fipscheck"
+        mkdir -p "${_fipscheckdir}"
+        cp -p "${srcmods}/.${_vmname}.hmac" "${_fipscheckdir}/${_vmname}-${kernel}.hmac"
+        ln_r /usr/lib64/fipscheck /usr/lib/fipscheck
+    else
+        dwarning "${srcmods}/.${_vmname}.hmac not found"
+    fi
 }
 
 # called by dracut
@@ -68,8 +80,9 @@ install() {
     inst_hook pre-pivot 01 "$moddir/fips-noboot.sh"
     inst_hook pre-udev 01 "$moddir/fips-load-crypto.sh"
     inst_script "$moddir/fips.sh" /sbin/fips.sh
+    inst_simple "$moddir/fips-lib.sh" "/lib/fips-lib.sh"
 
-    inst_multiple rmmod insmod mount uname umount sed
+    inst_multiple rmmod insmod mount uname umount sed ln
     inst_multiple -o sha512hmac \
                      fipscheck \
                      /usr/libexec/libkcapi/fipscheck \


### PR DESCRIPTION
In s390x, the first stage kernel and initrd, located in /boot/zipl, rely on .hmac files from the second stage, located in /boot. This is a problem in kernel updates and snapshot rollbacks.

To handle this:
- When the initrd is built, copy the .hmac file of the kernel image in /usr/lib64/fipscheck (within the initrd image).
- At boot, if the "initgrub" kernel command line option is present, mount /boot/zipl and use the kernel image from there.
- Symlink both the kernel image and its .hmac file to / in the initrd image, and perform `fipscheck` there.